### PR TITLE
Add per-job execution timeout with --timeout flag

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -153,6 +153,10 @@ rnx job run --volume=mydata python3 process_data.py
 # Job scheduling options
 rnx job run --schedule="1hour" backup.sh
 rnx job run --schedule="2025-12-25T00:00:00" maintenance.py
+
+# Execution timeout (terminates job if exceeded)
+rnx job run --timeout=5m long_running_task.sh
+rnx job run --timeout=30s --max-memory=256 quick_check.sh
 ```
 
 ## 🎨 Web Administration Interface

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -129,7 +129,7 @@ joblet:
 
   # Job execution settings
   maxConcurrentJobs: 100          # Maximum concurrent jobs
-  jobTimeout: "24h"               # Maximum job runtime
+  jobTimeout: "24h"               # Maximum job runtime (0 = unlimited). Can be overridden per-job with --timeout flag
 
   # Command validation
   validateCommands: true          # Validate commands before execution

--- a/docs/JOB_EXECUTION.md
+++ b/docs/JOB_EXECUTION.md
@@ -311,6 +311,7 @@ Use job UUIDs to:
 4. **COMPLETED** - Job finished successfully (exit code 0)
 5. **FAILED** - Job finished with error (non-zero exit code)
 6. **STOPPED** - Job manually stopped
+7. **TIMEOUT** - Job exceeded its execution timeout (exit code 124)
 
 ### Monitoring Job Progress
 
@@ -641,7 +642,8 @@ Common issues and solutions:
 3. **Job Hangs**
     - Check CPU limits
     - Monitor with `rnx job log <job-uuid>`
-    - Set appropriate timeout
+   - Set a per-job timeout: `rnx job run --timeout=5m long_task.sh`
+   - Or configure global timeout in `joblet-config.yml` via `jobTimeout`
 
 4. **File Not Found**
     - Verify upload succeeded

--- a/docs/RNX_CLI_REFERENCE.md
+++ b/docs/RNX_CLI_REFERENCE.md
@@ -74,21 +74,22 @@ rnx job run [parameters] <command> [arguments...]
 
 #### Command Parameters
 
-| Parameter          | Description                                                | Default Value  |
-|--------------------|------------------------------------------------------------|----------------|
-| `--max-cpu`        | Maximum CPU usage percentage (0-10000)                     | 0 (unlimited)  |
-| `--max-memory`     | Maximum memory in MB                                       | 0 (unlimited)  |
-| `--max-iobps`      | Maximum I/O bytes per second                               | 0 (unlimited)  |
-| `--cpu-cores`      | CPU cores to use (e.g., "0-3" or "1,3,5")                  | "" (all cores) |
-| `--gpu`            | Number of GPUs to allocate to the job                      | 0 (none)       |
-| `--gpu-memory`     | Minimum GPU memory required (e.g., "8GB", "4096MB")        | none           |
-| `--network`        | Network mode: bridge, isolated, none, or custom            | "bridge"       |
-| `--volume`         | Volume to mount (can be specified multiple times)          | none           |
+| Parameter          | Description                                                                           | Default Value  |
+|--------------------|---------------------------------------------------------------------------------------|----------------|
+| `--max-cpu`        | Maximum CPU usage percentage (0-10000)                                                | 0 (unlimited)  |
+| `--max-memory`     | Maximum memory in MB                                                                  | 0 (unlimited)  |
+| `--max-iobps`      | Maximum I/O bytes per second                                                          | 0 (unlimited)  |
+| `--cpu-cores`      | CPU cores to use (e.g., "0-3" or "1,3,5")                                             | "" (all cores) |
+| `--gpu`            | Number of GPUs to allocate to the job                                                 | 0 (none)       |
+| `--gpu-memory`     | Minimum GPU memory required (e.g., "8GB", "4096MB")                                   | none           |
+| `--network`        | Network mode: bridge, isolated, none, or custom                                       | "bridge"       |
+| `--volume`         | Volume to mount (can be specified multiple times)                                     | none           |
 | `--upload`         | Upload file or directory to workspace (auto-detects, can be specified multiple times) | none           |
-| `--runtime`        | Use pre-built runtime (e.g., openjdk-21, python-3.11-ml)   | none           |
-| `--env, -e`        | Environment variable (KEY=VALUE, visible in logs)          | none           |
-| `--secret-env, -s` | Secret environment variable (KEY=VALUE, hidden from logs)  | none           |
-| `--schedule`       | Schedule job execution (duration or RFC3339 time)          | immediate      |
+| `--runtime`        | Use pre-built runtime (e.g., openjdk-21, python-3.11-ml)                              | none           |
+| `--env, -e`        | Environment variable (KEY=VALUE, visible in logs)                                     | none           |
+| `--secret-env, -s` | Secret environment variable (KEY=VALUE, hidden from logs)                             | none           |
+| `--schedule`       | Schedule job execution (duration or RFC3339 time)                                     | immediate      |
+| `--timeout`        | Job execution timeout (e.g., "30s", "5m", "1h"). Overrides global config              | global config  |
 
 #### Examples
 
@@ -138,6 +139,10 @@ rnx job run --network=isolated ping google.com
 # Using runtime
 rnx job run --runtime=python-3.11-ml python -c "import torch; print(torch.__version__)"
 rnx job run --runtime=openjdk-21 java -version
+
+# Per-job execution timeout
+rnx job run --timeout=5m long_task.sh
+rnx job run --timeout=30s --max-memory=256 quick_check.sh
 
 # GPU acceleration
 rnx job run --gpu=1 python gpu_script.py

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/cilium/ebpf v0.20.0
-	github.com/ehsaniara/joblet-proto/v2 v2.5.8
+	github.com/ehsaniara/joblet-proto/v2 v2.5.9
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ehsaniara/joblet-proto/v2 v2.5.8 h1:OEa08GyyVjogPlnQQ2w1daQh1Dx3l472NH7C6MjoqXU=
 github.com/ehsaniara/joblet-proto/v2 v2.5.8/go.mod h1:Ie5fkoH5PkhxSHDJvTu+exdqUnUSWK8KjpENb+K5TVY=
+github.com/ehsaniara/joblet-proto/v2 v2.5.9 h1:J/B5eMb0Ueyn5Z4MhN8spBBNP6MXMJLWWEMfPt7NbYw=
+github.com/ehsaniara/joblet-proto/v2 v2.5.9/go.mod h1:Ie5fkoH5PkhxSHDJvTu+exdqUnUSWK8KjpENb+K5TVY=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/internal/joblet/core/interfaces/requests.go
+++ b/internal/joblet/core/interfaces/requests.go
@@ -41,6 +41,9 @@ type StartJobRequest struct {
 
 	// Working directory
 	WorkingDirectory string // Execution directory path
+
+	// Execution timeout (e.g., "30s", "5m", "1h"). Empty = use global config
+	Timeout string
 }
 
 // ResourceLimits encapsulates resource constraints for a job

--- a/internal/joblet/core/job/builder.go
+++ b/internal/joblet/core/job/builder.go
@@ -45,8 +45,9 @@ type BuildRequest struct {
 	JobType           domain.JobType
 	WorkingDirectory  string
 	Uploads           []domain.FileUpload
-	GPUCount          int32 // Number of GPUs requested
-	GPUMemoryMB       int64 // GPU memory requirement in MB
+	GPUCount          int32  // Number of GPUs requested
+	GPUMemoryMB       int64  // GPU memory requirement in MB
+	Timeout           string // Execution timeout (e.g., "30s", "5m", "1h"). Empty = use global config
 }
 
 // Build creates a new job from the request.
@@ -91,6 +92,18 @@ func (b *Builder) Build(req BuildRequest) (*domain.Job, error) {
 		GPUMemoryMB:       req.GPUMemoryMB,        // GPU memory requirement
 		GPUIndices:        []int32{},              // Will be populated during allocation
 		NodeId:            b.config.Server.NodeId, // Unique identifier of the Joblet node
+	}
+
+	// Parse per-job timeout if specified
+	if req.Timeout != "" {
+		timeout, err := time.ParseDuration(req.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("invalid timeout: %w", err)
+		}
+		if timeout < 0 {
+			return nil, fmt.Errorf("invalid timeout: must be non-negative")
+		}
+		job.Timeout = timeout
 	}
 
 	// Apply resource limits with defaults

--- a/internal/joblet/core/joblet.go
+++ b/internal/joblet/core/joblet.go
@@ -148,6 +148,7 @@ func (j *Joblet) StartJob(ctx context.Context, req interfaces.StartJobRequest) (
 		WorkingDirectory:  req.WorkingDirectory,
 		GPUCount:          req.GPUCount,    // GPU requirements
 		GPUMemoryMB:       req.GPUMemoryMB, // GPU memory requirement
+		Timeout:           req.Timeout,     // Per-job timeout
 	}
 
 	log := j.logger.WithFields(
@@ -589,8 +590,12 @@ func (j *Joblet) monitorJob(ctx context.Context, cmd platform.Command, job *doma
 		waitDone <- cmd.Wait()
 	}()
 
-	// Setup timeout if configured (0 or negative = no timeout)
+	// Setup timeout: per-job timeout takes precedence over global config
+	// (0 or negative = no timeout)
 	timeout := j.config.Joblet.JobTimeout
+	if job.Timeout > 0 {
+		timeout = job.Timeout
+	}
 	var timeoutChan <-chan time.Time
 	if timeout > 0 {
 		timeoutChan = time.After(timeout)
@@ -611,9 +616,13 @@ func (j *Joblet) monitorJob(ctx context.Context, cmd platform.Command, job *doma
 
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), j.config.Joblet.CleanupTimeout)
 		if job.Type.IsRuntimeBuild() {
-			j.cleanup.CleanupJobWithProcessSystemOnly(cleanupCtx, job.Uuid, job.Pid)
+			if err := j.cleanup.CleanupJobWithProcessSystemOnly(cleanupCtx, job.Uuid, job.Pid); err != nil {
+				log.Error("timeout cleanup failed for runtime build job", "error", err)
+			}
 		} else {
-			j.cleanup.CleanupJobWithProcess(cleanupCtx, job.Uuid, job.Pid)
+			if err := j.cleanup.CleanupJobWithProcess(cleanupCtx, job.Uuid, job.Pid); err != nil {
+				log.Error("timeout cleanup failed", "error", err)
+			}
 		}
 		cancel()
 

--- a/internal/joblet/core/joblet.go
+++ b/internal/joblet/core/joblet.go
@@ -577,12 +577,56 @@ func (j *Joblet) DeleteAllJobs(ctx context.Context, req interfaces.DeleteAllJobs
 // monitorJob monitors a running job until completion asynchronously.
 // Waits for process completion, determines exit code, updates job status,
 // and triggers cleanup (special handling for runtime builds to preserve artifacts).
+// If JobTimeout is configured and positive, the job will be terminated if it exceeds
+// the timeout duration.
 func (j *Joblet) monitorJob(ctx context.Context, cmd platform.Command, job *domain.Job) {
 	log := j.logger.WithField("job_uuid", job.Uuid)
 	log.Debug("starting job monitoring")
 
-	// Wait for completion
-	err := cmd.Wait()
+	// Channel to receive Wait() result
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- cmd.Wait()
+	}()
+
+	// Setup timeout if configured (0 or negative = no timeout)
+	timeout := j.config.Joblet.JobTimeout
+	var timeoutChan <-chan time.Time
+	if timeout > 0 {
+		timeoutChan = time.After(timeout)
+		log.Debug("job timeout configured", "timeout", timeout)
+	}
+
+	// Race between completion and timeout
+	var waitErr error
+	var timedOut bool
+
+	select {
+	case waitErr = <-waitDone:
+		// Process completed normally
+	case <-timeoutChan:
+		// Timeout exceeded - terminate job
+		timedOut = true
+		log.Warn("job execution timeout exceeded", "timeout", timeout)
+
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), j.config.Joblet.CleanupTimeout)
+		if job.Type.IsRuntimeBuild() {
+			j.cleanup.CleanupJobWithProcessSystemOnly(cleanupCtx, job.Uuid, job.Pid)
+		} else {
+			j.cleanup.CleanupJobWithProcess(cleanupCtx, job.Uuid, job.Pid)
+		}
+		cancel()
+
+		// Wait for process to terminate after cleanup
+		select {
+		case waitErr = <-waitDone:
+		case <-time.After(5 * time.Second):
+			log.Error("process did not terminate after cleanup")
+		}
+	case <-ctx.Done():
+		log.Info("context canceled during job monitoring")
+		return
+	}
 
 	// Give a brief moment for final log chunks to be written and published
 	// cmd.Wait() ensures pipes are closed, but async pubsub publishes might still be in flight
@@ -591,9 +635,14 @@ func (j *Joblet) monitorJob(ctx context.Context, cmd platform.Command, job *doma
 	// Determine final status
 	var exitCode int32
 	now := time.Now()
-	if err != nil {
+
+	if timedOut {
+		job.Status = domain.StatusTimeout
+		job.ExitCode = 124 // Unix timeout convention
+		job.EndTime = &now
+	} else if waitErr != nil {
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if errors.As(waitErr, &exitErr) {
 			exitCode = int32(exitErr.ExitCode())
 		} else {
 			exitCode = -1
@@ -602,9 +651,8 @@ func (j *Joblet) monitorJob(ctx context.Context, cmd platform.Command, job *doma
 		job.ExitCode = exitCode
 		job.EndTime = &now
 	} else {
-		exitCode = 0
 		job.Status = domain.StatusCompleted
-		job.ExitCode = exitCode
+		job.ExitCode = 0
 		job.EndTime = &now
 	}
 
@@ -630,22 +678,25 @@ func (j *Joblet) monitorJob(ctx context.Context, cmd platform.Command, job *doma
 	}
 
 	// Cleanup resources - but handle runtime build jobs specially
-	if job.Type.IsRuntimeBuild() {
-		// For runtime builds: clean system resources but preserve filesystem artifacts
-		if err := j.cleanup.CleanupJobSystemResourcesOnly(job.Uuid); err != nil {
-			log.Error("system resource cleanup failed for runtime build job", "error", err)
+	// Skip cleanup if already done during timeout handling
+	if !timedOut {
+		if job.Type.IsRuntimeBuild() {
+			// For runtime builds: clean system resources but preserve filesystem artifacts
+			if err := j.cleanup.CleanupJobSystemResourcesOnly(job.Uuid); err != nil {
+				log.Error("system resource cleanup failed for runtime build job", "error", err)
+			} else {
+				log.Info("runtime build job completed - system resources cleaned, artifacts preserved",
+					"jobType", job.Type, "runtimesPath", "/opt/joblet/runtimes")
+			}
 		} else {
-			log.Info("runtime build job completed - system resources cleaned, artifacts preserved",
-				"jobType", job.Type, "runtimesPath", "/opt/joblet/runtimes")
-		}
-	} else {
-		// For regular jobs: full cleanup
-		if err := j.cleanup.CleanupJob(job.Uuid); err != nil {
-			log.Error("cleanup failed during monitoring", "error", err)
+			// For regular jobs: full cleanup
+			if err := j.cleanup.CleanupJob(job.Uuid); err != nil {
+				log.Error("cleanup failed during monitoring", "error", err)
+			}
 		}
 	}
 
-	log.Info("job completed", "exitCode", exitCode)
+	log.Info("job monitoring complete", "status", job.Status, "exitCode", job.ExitCode)
 }
 
 // Helper methods

--- a/internal/joblet/domain/job.go
+++ b/internal/joblet/domain/job.go
@@ -76,6 +76,9 @@ type Job struct {
 	// Node identification
 	NodeId string // Unique identifier of the Joblet node that executed this job
 
+	// Execution timeout (per-job override; 0 = use global config)
+	Timeout time.Duration
+
 	// Value object accessors (for new code to use value objects)
 	jobUUID     *values.JobUUID     // Cached value object for UUID
 	cgroupPath  *values.CgroupPath  // Cached value object for CgroupPath
@@ -389,6 +392,9 @@ func (j *Job) DeepCopy() *Job {
 
 		// Node identification
 		NodeId: j.NodeId,
+
+		// Timeout
+		Timeout: j.Timeout,
 	}
 
 	// Copy slices

--- a/internal/joblet/domain/job.go
+++ b/internal/joblet/domain/job.go
@@ -21,6 +21,7 @@ const (
 	StatusInitializing JobStatus = "INITIALIZING"
 	StatusCanceled     JobStatus = "CANCELED"
 	StatusStopping     JobStatus = "STOPPING"
+	StatusTimeout      JobStatus = "TIMEOUT"
 )
 
 var (
@@ -93,7 +94,8 @@ func (j *Job) IsRunning() bool {
 
 // IsCompleted returns true if the job has completed execution
 func (j *Job) IsCompleted() bool {
-	return j.Status == StatusCompleted || j.Status == StatusFailed || j.Status == StatusStopped
+	return j.Status == StatusCompleted || j.Status == StatusFailed ||
+		j.Status == StatusStopped || j.Status == StatusTimeout
 }
 
 // IsScheduled returns true if the job is scheduled for future execution

--- a/internal/joblet/domain/job_test.go
+++ b/internal/joblet/domain/job_test.go
@@ -184,6 +184,7 @@ func TestJobIsRunning(t *testing.T) {
 		{StatusCompleted, false},
 		{StatusFailed, false},
 		{StatusStopped, false},
+		{StatusTimeout, false},
 	}
 
 	for _, tt := range tests {
@@ -205,6 +206,7 @@ func TestJobIsCompleted(t *testing.T) {
 		{StatusCompleted, true},
 		{StatusFailed, true},
 		{StatusStopped, true},
+		{StatusTimeout, true},
 	}
 
 	for _, tt := range tests {
@@ -213,5 +215,32 @@ func TestJobIsCompleted(t *testing.T) {
 			t.Errorf("IsCompleted() for status %v: expected %v, got %v",
 				tt.status, tt.expected, job.IsCompleted())
 		}
+	}
+}
+
+func TestJobTimeoutTransition(t *testing.T) {
+	job := &Job{
+		Uuid:   "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+		Status: StatusRunning,
+		Pid:    1234,
+	}
+
+	// Simulate timeout
+	job.Status = StatusTimeout
+	job.ExitCode = 124 // Unix timeout convention
+	endTime := time.Now()
+	job.EndTime = &endTime
+
+	if job.Status != StatusTimeout {
+		t.Errorf("Expected status TIMEOUT, got %v", job.Status)
+	}
+	if job.ExitCode != 124 {
+		t.Errorf("Expected exit code 124, got %v", job.ExitCode)
+	}
+	if job.EndTime == nil {
+		t.Error("Expected end time to be set")
+	}
+	if !job.IsCompleted() {
+		t.Error("Expected job with TIMEOUT status to be completed")
 	}
 }

--- a/internal/joblet/mappers/job_mapper.go
+++ b/internal/joblet/mappers/job_mapper.go
@@ -40,6 +40,10 @@ func (m *JobMapper) DomainToProtobuf(job *domain.Job) *pb.Job {
 		NodeId:            job.NodeId,             // Unique identifier of the Joblet node
 	}
 
+	if job.Timeout > 0 {
+		pbJob.Timeout = job.Timeout.String()
+	}
+
 	pbJob.EndTime = job.FormattedEndTime()             // Use job's formatting method
 	pbJob.ScheduledTime = job.FormattedScheduledTime() // Use job's formatting method
 
@@ -169,6 +173,7 @@ func (m *JobMapper) ProtobufToStartJobRequest(req *pb.RunJobRequest) (*interface
 		GPUCount:          req.GpuCount,
 		GPUMemoryMB:       int64(req.GpuMemoryMb),
 		WorkingDirectory:  req.WorkDir,
+		Timeout:           req.Timeout,
 	}, nil
 }
 
@@ -202,5 +207,6 @@ func (m *JobMapper) StartJobRequestToProtobuf(req *interfaces.StartJobRequest) *
 		GpuCount:          req.GPUCount,
 		GpuMemoryMb:       int32(req.GPUMemoryMB),
 		WorkDir:           req.WorkingDirectory,
+		Timeout:           req.Timeout,
 	}
 }

--- a/internal/joblet/server/job_service.go
+++ b/internal/joblet/server/job_service.go
@@ -986,7 +986,7 @@ func (s *JobServiceServer) streamLiveMetrics(stream grpc.ServerStreamingServer[p
 			}
 
 			if event.Type == "UPDATED" {
-				if event.Status == "COMPLETED" || event.Status == "FAILED" || event.Status == "STOPPED" {
+				if event.Status == "COMPLETED" || event.Status == "FAILED" || event.Status == "STOPPED" || event.Status == "TIMEOUT" {
 					if !jobCompleted {
 						jobCompleted = true
 						drainDeadline = time.Now().Add(500 * time.Millisecond)
@@ -1416,7 +1416,7 @@ func (s *JobServiceServer) streamLiveTelematics(stream grpc.ServerStreamingServe
 			}
 
 			if event.Type == "UPDATED" {
-				if event.Status == "COMPLETED" || event.Status == "FAILED" || event.Status == "STOPPED" {
+				if event.Status == "COMPLETED" || event.Status == "FAILED" || event.Status == "STOPPED" || event.Status == "TIMEOUT" {
 					if !jobCompleted {
 						jobCompleted = true
 						drainDeadline = time.Now().Add(500 * time.Millisecond)

--- a/internal/joblet/server/job_service.go
+++ b/internal/joblet/server/job_service.go
@@ -193,6 +193,7 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 		Environment:       req.Environment,
 		SecretEnvironment: req.SecretEnvironment,
 		JobType:           jobType,
+		Timeout:           req.Timeout,
 	}
 
 	if err := s.validateJobRequest(jobRequest); err != nil {
@@ -336,6 +337,7 @@ func (s *JobServiceServer) GetJobStatus(ctx context.Context, req *pb.GetJobStatu
 		GpuCount:          pbJob.GpuCount,
 		GpuMemoryMb:       pbJob.GpuMemoryMb,
 		NodeId:            job.NodeId,
+		Timeout:           pbJob.Timeout,
 	}, nil
 }
 

--- a/internal/rnx/jobs/run.go
+++ b/internal/rnx/jobs/run.go
@@ -121,7 +121,8 @@ Flags:
   --secret-env=KEY=VALUE  Set secret environment variable (hidden from logs)
   -s KEY=VALUE            Short form of --secret-env
   --gpu=N             Request N GPUs for the job (requires GPU support enabled)
-  --gpu-memory=SIZE   Minimum GPU memory required (e.g., 8GB, 1024MB, 2048)`,
+  --gpu-memory=SIZE   Minimum GPU memory required (e.g., 8GB, 1024MB, 2048)
+  --timeout=DURATION  Job execution timeout (e.g., 30s, 5m, 1h). Overrides global config`,
 		Args:               cobra.MinimumNArgs(1),
 		RunE:               runRun,
 		DisableFlagParsing: true,
@@ -151,6 +152,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		secretEnvVars []string
 		gpuCount      int32
 		gpuMemoryMB   int32
+		timeout       string
 	)
 
 	commandStartIndex := -1
@@ -223,6 +225,8 @@ func runRun(cmd *cobra.Command, args []string) error {
 			if val, err := parseIntFlag(arg, "--gpu="); err == nil {
 				gpuCount = int32(val)
 			}
+		} else if strings.HasPrefix(arg, "--timeout=") {
+			timeout = strings.TrimPrefix(arg, "--timeout=")
 		} else if strings.HasPrefix(arg, "--gpu-memory=") {
 			gpuMemoryStr := strings.TrimPrefix(arg, "--gpu-memory=")
 			// Parse GPU memory - support formats like "8GB", "1024MB", or just "1024"
@@ -326,6 +330,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		SecretEnvironment: secretEnvironment,
 		GpuCount:          gpuCount,
 		GpuMemoryMb:       gpuMemoryMB,
+		Timeout:           timeout,
 	}
 
 	// Submit job

--- a/tests/ci/common/test_helpers.sh
+++ b/tests/ci/common/test_helpers.sh
@@ -174,7 +174,7 @@ wait_for_job_completion() {
     while [[ $elapsed -lt $timeout ]]; do
         local status
         if status=$("$RNX_BINARY" --config "$RNX_CONFIG" job status "$job_id" 2>/dev/null | jq -r '.status' 2>/dev/null); then
-            if [[ "$status" == "COMPLETED" || "$status" == "STOPPED" || "$status" == "FAILED" ]]; then
+            if [[ "$status" == "COMPLETED" || "$status" == "STOPPED" || "$status" == "FAILED" || "$status" == "TIMEOUT" ]]; then
                 return 0
             fi
         fi

--- a/tests/ci/run_ci_tests.sh
+++ b/tests/ci/run_ci_tests.sh
@@ -65,6 +65,9 @@ run_test_suite "mTLS Authentication Tests" "$SCRIPT_DIR/test_mtls_auth.sh"
 run_test_suite "Volume Operations Tests" "$SCRIPT_DIR/test_volume_operations.sh"
 run_test_suite "Default Disk Quota Tests" "$SCRIPT_DIR/test_default_disk_quota.sh"
 
+# Timeout tests
+run_test_suite "Job Timeout Tests" "$SCRIPT_DIR/test_job_timeout.sh"
+
 # Print final summary and handle CI environment limitations
 if print_suite_summary; then
     echo "CI-compatible E2E tests completed successfully!"

--- a/tests/ci/test_job_timeout.sh
+++ b/tests/ci/test_job_timeout.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+set -e
+
+# Job timeout test for CI environment
+# Tests per-job timeout via --timeout flag
+
+source "$(dirname "$0")/common/test_helpers.sh"
+
+test_job_timeout_terminates() {
+    echo "Testing job timeout terminates long-running job..."
+
+    # Run a long-running job with a short timeout
+    local job_output
+    job_output=$("$RNX_BINARY" --config "$RNX_CONFIG" job run --timeout=3s sleep 60 2>&1)
+
+    # Extract job ID
+    local job_id
+    job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$job_id" ]]; then
+        echo "Failed to get job ID"
+        echo "Output: $job_output"
+        return 1
+    fi
+
+    echo "  Job ID: $job_id (timeout=3s, command=sleep 60)"
+
+    # Wait for job to reach TIMEOUT status (give extra buffer beyond the 3s timeout)
+    local elapsed=0
+    local max_wait=15
+    local status=""
+
+    while [[ $elapsed -lt $max_wait ]]; do
+        local status_output
+        status_output=$("$RNX_BINARY" --config "$RNX_CONFIG" job status "$job_id" 2>&1)
+        status=$(echo "$status_output" | grep "^Status:" | awk '{print $2}')
+
+        if [[ "$status" == "TIMEOUT" || "$status" == "FAILED" || "$status" == "COMPLETED" || "$status" == "STOPPED" ]]; then
+            break
+        fi
+
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    if [[ "$status" != "TIMEOUT" ]]; then
+        echo "Expected status TIMEOUT, got: $status"
+        return 1
+    fi
+
+    echo "✓ Job timeout terminates correctly (status=$status)"
+}
+
+test_job_timeout_exit_code() {
+    echo "Testing timed-out job has exit code 124..."
+
+    local job_output
+    job_output=$("$RNX_BINARY" --config "$RNX_CONFIG" job run --timeout=3s sleep 60 2>&1)
+
+    local job_id
+    job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$job_id" ]]; then
+        echo "Failed to get job ID"
+        echo "Output: $job_output"
+        return 1
+    fi
+
+    # Wait for timeout
+    local elapsed=0
+    local max_wait=15
+
+    while [[ $elapsed -lt $max_wait ]]; do
+        local status_output
+        status_output=$("$RNX_BINARY" --config "$RNX_CONFIG" job status "$job_id" 2>&1)
+        local status
+        status=$(echo "$status_output" | grep "^Status:" | awk '{print $2}')
+
+        if [[ "$status" == "TIMEOUT" || "$status" == "FAILED" || "$status" == "COMPLETED" || "$status" == "STOPPED" ]]; then
+            break
+        fi
+
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    # Check exit code
+    local status_output
+    status_output=$("$RNX_BINARY" --config "$RNX_CONFIG" job status "$job_id" 2>&1)
+    local exit_code
+    exit_code=$(echo "$status_output" | grep "Exit Code:" | awk '{print $NF}')
+
+    if [[ "$exit_code" != "124" ]]; then
+        echo "Expected exit code 124, got: $exit_code"
+        echo "Full status output:"
+        echo "$status_output"
+        return 1
+    fi
+
+    echo "✓ Timed-out job has correct exit code 124"
+}
+
+test_job_no_timeout_completes_normally() {
+    echo "Testing job without timeout completes normally..."
+
+    # Run a quick job without explicit timeout (should complete fine)
+    local job_output
+    job_output=$("$RNX_BINARY" --config "$RNX_CONFIG" job run echo "no timeout" 2>&1)
+
+    local job_id
+    job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$job_id" ]]; then
+        echo "Failed to get job ID"
+        echo "Output: $job_output"
+        return 1
+    fi
+
+    # Wait for completion
+    sleep 2
+
+    local status_output
+    status_output=$("$RNX_BINARY" --config "$RNX_CONFIG" job status "$job_id" 2>&1)
+    local status
+    status=$(echo "$status_output" | grep "^Status:" | awk '{print $2}')
+
+    if [[ "$status" != "COMPLETED" ]]; then
+        echo "Expected status COMPLETED, got: $status"
+        return 1
+    fi
+
+    echo "✓ Job without timeout completes normally"
+}
+
+test_job_completes_before_timeout() {
+    echo "Testing job that finishes before timeout..."
+
+    # Run a quick job with a generous timeout
+    local job_output
+    job_output=$("$RNX_BINARY" --config "$RNX_CONFIG" job run --timeout=30s echo "fast job" 2>&1)
+
+    local job_id
+    job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$job_id" ]]; then
+        echo "Failed to get job ID"
+        echo "Output: $job_output"
+        return 1
+    fi
+
+    # Wait for completion
+    sleep 2
+
+    local status_output
+    status_output=$("$RNX_BINARY" --config "$RNX_CONFIG" job status "$job_id" 2>&1)
+    local status
+    status=$(echo "$status_output" | grep "^Status:" | awk '{print $2}')
+
+    if [[ "$status" != "COMPLETED" ]]; then
+        echo "Job with generous timeout should COMPLETE, got: $status"
+        return 1
+    fi
+
+    echo "✓ Job completes normally before timeout"
+}
+
+# Run all tests
+main() {
+    echo "Starting CI-compatible job timeout tests..."
+
+    test_job_timeout_terminates
+    test_job_timeout_exit_code
+    test_job_no_timeout_completes_normally
+    test_job_completes_before_timeout
+
+    echo "All job timeout tests passed!"
+}
+
+main "$@"

--- a/tests/e2e/lib/test_framework.sh
+++ b/tests/e2e/lib/test_framework.sh
@@ -188,7 +188,7 @@ get_job_logs() {
     # Wait for job to complete with exponential backoff
     for i in $(seq 1 $max_attempts); do
         local status=$(check_job_status "$job_id")
-        if [[ "$status" == "COMPLETED" || "$status" == "FAILED" ]]; then
+        if [[ "$status" == "COMPLETED" || "$status" == "FAILED" || "$status" == "TIMEOUT" ]]; then
             break
         fi
         # Start with shorter waits, increase gradually

--- a/tests/e2e/tests/18_timeout_test.sh
+++ b/tests/e2e/tests/18_timeout_test.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+# E2E Test: Job Execution Timeout
+# Tests per-job timeout via --timeout flag
+# Verifies that jobs exceeding their timeout are terminated with TIMEOUT status and exit code 124
+
+source "$(dirname "$0")/../lib/test_framework.sh"
+
+test_suite_init "Job Execution Timeout Tests"
+
+# ============================================
+# Test Helpers
+# ============================================
+
+# Wait for a job to reach a terminal status, with a maximum wait time
+wait_for_terminal_status() {
+    local job_id="$1"
+    local max_wait="${2:-20}"
+    local elapsed=0
+
+    while [[ $elapsed -lt $max_wait ]]; do
+        local status
+        status=$(check_job_status "$job_id")
+        if [[ "$status" == "COMPLETED" || "$status" == "FAILED" || "$status" == "STOPPED" || "$status" == "TIMEOUT" ]]; then
+            echo "$status"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    echo "UNKNOWN"
+    return 1
+}
+
+# Get exit code from job status output
+get_exit_code() {
+    local job_id="$1"
+    "$RNX_BINARY" job status "$job_id" 2>/dev/null | grep "Exit Code:" | sed 's/\x1b\[[0-9;]*m//g' | awk '{print $NF}'
+}
+
+# ============================================
+# Tests
+# ============================================
+
+test_section "Per-Job Timeout Enforcement"
+
+# Test 1: Job exceeding timeout is terminated with TIMEOUT status
+test_timeout_terminates_job() {
+    local job_output
+    job_output=$("$RNX_BINARY" job run --timeout=3s sleep 60 2>&1)
+    local job_id
+    job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$job_id" ]]; then
+        echo "    Failed to create job"
+        return 1
+    fi
+
+    echo "    Job $job_id: timeout=3s, command=sleep 60"
+
+    local status
+    status=$(wait_for_terminal_status "$job_id" 15)
+
+    assert_equals "$status" "TIMEOUT" "Job should have TIMEOUT status"
+}
+run_test "Job exceeding timeout gets TIMEOUT status" test_timeout_terminates_job
+
+# Test 2: Timed-out job has exit code 124
+test_timeout_exit_code() {
+    local job_output
+    job_output=$("$RNX_BINARY" job run --timeout=3s sleep 60 2>&1)
+    local job_id
+    job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$job_id" ]]; then
+        echo "    Failed to create job"
+        return 1
+    fi
+
+    wait_for_terminal_status "$job_id" 15 >/dev/null
+
+    local exit_code
+    exit_code=$(get_exit_code "$job_id")
+
+    assert_equals "$exit_code" "124" "Exit code should be 124 (Unix timeout convention)"
+}
+run_test "Timed-out job has exit code 124" test_timeout_exit_code
+
+test_section "Timeout Does Not Affect Normal Jobs"
+
+# Test 3: Job completing before timeout succeeds normally
+test_fast_job_with_timeout() {
+    local job_output
+    job_output=$("$RNX_BINARY" job run --timeout=30s echo "fast" 2>&1)
+    local job_id
+    job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$job_id" ]]; then
+        echo "    Failed to create job"
+        return 1
+    fi
+
+    local status
+    status=$(wait_for_terminal_status "$job_id" 10)
+
+    assert_equals "$status" "COMPLETED" "Fast job with generous timeout should COMPLETE"
+}
+run_test "Fast job with generous timeout completes normally" test_fast_job_with_timeout
+
+# Test 4: Job without --timeout uses global config (should complete quickly)
+test_no_timeout_flag() {
+    local job_output
+    job_output=$("$RNX_BINARY" job run echo "no timeout flag" 2>&1)
+    local job_id
+    job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$job_id" ]]; then
+        echo "    Failed to create job"
+        return 1
+    fi
+
+    local status
+    status=$(wait_for_terminal_status "$job_id" 10)
+
+    assert_equals "$status" "COMPLETED" "Job without timeout flag should complete normally"
+}
+run_test "Job without --timeout flag completes normally" test_no_timeout_flag
+
+# Test 5: Job that fails before timeout gets FAILED (not TIMEOUT)
+test_failing_job_with_timeout() {
+    local job_output
+    job_output=$("$RNX_BINARY" job run --timeout=30s sh -c "exit 1" 2>&1)
+    local job_id
+    job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$job_id" ]]; then
+        echo "    Failed to create job"
+        return 1
+    fi
+
+    local status
+    status=$(wait_for_terminal_status "$job_id" 10)
+
+    assert_equals "$status" "FAILED" "Failing job should get FAILED status, not TIMEOUT"
+}
+run_test "Failing job with timeout gets FAILED (not TIMEOUT)" test_failing_job_with_timeout
+
+# ============================================
+# Summary
+# ============================================
+
+echo -e "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${CYAN}  Timeout Test Results${NC}"
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "  Total:   $TOTAL_TESTS"
+echo -e "  ${GREEN}Passed:  $PASSED_TESTS${NC}"
+echo -e "  ${RED}Failed:  $FAILED_TESTS${NC}"
+echo -e "  ${YELLOW}Skipped: $SKIPPED_TESTS${NC}"
+
+if [[ $FAILED_TESTS -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                   
  - Add per-job execution timeout support via `--timeout` flag on `rnx job run`                                                                                                                                                                                                
  - Enforce the existing global `JobTimeout` config that was previously defined but never used                                                                                                                                                                                 
  - Jobs exceeding their timeout are terminated with `TIMEOUT` status and exit code 124                                                                                                                                                                                        
                                                                                                                                                                                                                                                                               
  ## Changes                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                               
  ### Proto (joblet-proto v2.5.9)                                                                                                                                                                                                                                              
  - Added `timeout` field to `RunJobRequest`, `Job`, and `GetJobStatusResponse` messages                                                                                                                                                                                       
                                                                                                                                                                                                                                                                               
  ### Domain & Core                                                                                                                                                                                                                                                            
  - Added `StatusTimeout` constant and `Timeout time.Duration` field to `domain.Job`                                                                                                                                                                                           
  - `IsCompleted()` now includes `TIMEOUT` status                                                                                                                                                                                                                              
  - `monitorJob()` races process completion against timeout using select                                                                                                                                                                                                       
  - Per-job timeout takes precedence over global config; 0 = use global default (1h)                                                                                                                                                                                           
                                                                                                                                                                                                                                                                               
  ### Server & Mappers                                                                                                                                                                                                                                                         
  - `convertToJobRequest` and `GetJobStatus` pass timeout through the full request/response chain                                                                                                                                                                              
  - All mapper methods (`DomainToProtobuf`, `ProtobufToStartJobRequest`, `StartJobRequestToProtobuf`) map timeout                                                                                                                                                              
  - Streaming completion checks include `TIMEOUT` status                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                               
  ### CLI                                                                                                                                                                                                                                                                      
  - Added `--timeout=DURATION` flag to `rnx job run` (e.g., `--timeout=30s`, `--timeout=5m`) 