### PR TITLE
map pkg/errors sentinels to gRPC status codes

### DIFF
--- a/internal/joblet/adapters/volume_store_adapter.go
+++ b/internal/joblet/adapters/volume_store_adapter.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ehsaniara/joblet/internal/joblet/domain"
+	pkgerrors "github.com/ehsaniara/joblet/pkg/errors"
 	"github.com/ehsaniara/joblet/pkg/logger"
 )
 
@@ -193,7 +194,7 @@ func (a *volumeStoreAdapter) RemoveVolume(name string) error {
 	a.countsMutex.RUnlock()
 
 	if jobCount > 0 {
-		return fmt.Errorf("volume is currently in use by %d job(s)", jobCount)
+		return fmt.Errorf("%w: volume is currently in use by %d job(s)", pkgerrors.ErrVolumeInUse, jobCount)
 	}
 
 	// Get volume for statistics before deletion
@@ -205,13 +206,13 @@ func (a *volumeStoreAdapter) RemoveVolume(name string) error {
 	}
 
 	if !exists {
-		return fmt.Errorf("volume not found: %s", name)
+		return fmt.Errorf("%w: %s", pkgerrors.ErrVolumeNotFound, name)
 	}
 
 	// Remove from store
 	if err := a.volumeStore.Delete(ctx, name); err != nil {
 		if err.Error() == "key not found" {
-			return fmt.Errorf("volume not found: %s", name)
+			return fmt.Errorf("%w: %s", pkgerrors.ErrVolumeNotFound, name)
 		}
 		a.logger.Error("failed to remove volume from store", "volumeName", name, "error", err)
 		return fmt.Errorf("failed to remove volume: %w", err)
@@ -247,7 +248,7 @@ func (a *volumeStoreAdapter) IncrementJobCount(name string) error {
 	// Check if volume exists
 	_, exists := a.GetVolume(name)
 	if !exists {
-		return fmt.Errorf("volume not found: %s", name)
+		return fmt.Errorf("%w: %s", pkgerrors.ErrVolumeNotFound, name)
 	}
 
 	a.countsMutex.Lock()
@@ -282,7 +283,7 @@ func (a *volumeStoreAdapter) DecrementJobCount(name string) error {
 
 	count, exists := a.jobCounts[name]
 	if !exists {
-		return fmt.Errorf("volume not found: %s", name)
+		return fmt.Errorf("%w: %s", pkgerrors.ErrVolumeNotFound, name)
 	}
 
 	if count <= 0 {

--- a/internal/joblet/core/job/builder.go
+++ b/internal/joblet/core/job/builder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ehsaniara/joblet/internal/joblet/domain"
 	"github.com/ehsaniara/joblet/pkg/config"
+	pkgerrors "github.com/ehsaniara/joblet/pkg/errors"
 	"github.com/ehsaniara/joblet/pkg/logger"
 )
 
@@ -98,10 +99,10 @@ func (b *Builder) Build(req BuildRequest) (*domain.Job, error) {
 	if req.Timeout != "" {
 		timeout, err := time.ParseDuration(req.Timeout)
 		if err != nil {
-			return nil, fmt.Errorf("invalid timeout: %w", err)
+			return nil, fmt.Errorf("%w: invalid timeout: %v", pkgerrors.ErrInvalidJobSpec, err)
 		}
 		if timeout < 0 {
-			return nil, fmt.Errorf("invalid timeout: must be non-negative")
+			return nil, fmt.Errorf("%w: invalid timeout: must be non-negative", pkgerrors.ErrInvalidJobSpec)
 		}
 		job.Timeout = timeout
 	}
@@ -111,10 +112,10 @@ func (b *Builder) Build(req BuildRequest) (*domain.Job, error) {
 
 	// Basic resource limit validation (simplified)
 	if job.Limits.CPU.Value() < 0 || job.Limits.CPU.Value() > 100 {
-		return nil, fmt.Errorf("invalid CPU limit: must be between 0-100")
+		return nil, fmt.Errorf("%w: invalid CPU limit: must be between 0-100", pkgerrors.ErrInvalidResourceSpec)
 	}
 	if job.Limits.Memory.Bytes() < 0 {
-		return nil, fmt.Errorf("invalid memory limit: must be positive")
+		return nil, fmt.Errorf("%w: invalid memory limit: must be positive", pkgerrors.ErrInvalidResourceSpec)
 	}
 
 	b.logger.Debug("job built successfully",

--- a/internal/joblet/core/joblet.go
+++ b/internal/joblet/core/joblet.go
@@ -26,6 +26,7 @@ import (
 	metricsdomain "github.com/ehsaniara/joblet/internal/joblet/metrics/domain"
 	"github.com/ehsaniara/joblet/internal/joblet/scheduler"
 	"github.com/ehsaniara/joblet/pkg/config"
+	pkgerrors "github.com/ehsaniara/joblet/pkg/errors"
 	"github.com/ehsaniara/joblet/pkg/logger"
 	"github.com/ehsaniara/joblet/pkg/platform"
 )
@@ -168,7 +169,7 @@ func (j *Joblet) StartJob(ctx context.Context, req interfaces.StartJobRequest) (
 
 	// 1. Basic request validation (simplified)
 	if internalReq.Command == "" {
-		return nil, fmt.Errorf("command cannot be empty")
+		return nil, fmt.Errorf("%w: command cannot be empty", pkgerrors.ErrInvalidJobSpec)
 	}
 
 	// 2. Build the job
@@ -360,7 +361,7 @@ func (j *Joblet) executeScheduledJob(ctx context.Context, jobObj *domain.Job) er
 	// Get fresh job state from store to check for cancellation
 	freshJob, exists := j.store.Job(jobObj.Uuid)
 	if !exists {
-		return fmt.Errorf("job not found: %s", jobObj.Uuid)
+		return fmt.Errorf("%w: %s", pkgerrors.ErrJobNotFound, jobObj.Uuid)
 	}
 
 	// Prevent execution of canceled jobs (defensive check against race conditions)
@@ -393,7 +394,7 @@ func (j *Joblet) StopJob(ctx context.Context, req interfaces.StopJobRequest) err
 
 	jb, exists := j.store.Job(req.JobUUID)
 	if !exists {
-		return fmt.Errorf("job not found: %s", req.JobUUID)
+		return fmt.Errorf("%w: %s", pkgerrors.ErrJobNotFound, req.JobUUID)
 	}
 
 	// Handle scheduled jobs
@@ -413,7 +414,7 @@ func (j *Joblet) StopJob(ctx context.Context, req interfaces.StopJobRequest) err
 
 	// Handle running jobs
 	if !jb.IsRunning() {
-		return fmt.Errorf("job is not running: %s (status: %s)", req.JobUUID, jb.Status)
+		return fmt.Errorf("%w: %s (status: %s)", pkgerrors.ErrJobNotRunning, req.JobUUID, jb.Status)
 	}
 
 	// Check if cleanup is already in progress (from monitor)
@@ -464,12 +465,12 @@ func (j *Joblet) DeleteJob(ctx context.Context, req interfaces.DeleteJobRequest)
 	// Check if job exists
 	jb, exists := j.store.Job(req.JobUUID)
 	if !exists {
-		return fmt.Errorf("job not found: %s", req.JobUUID)
+		return fmt.Errorf("%w: %s", pkgerrors.ErrJobNotFound, req.JobUUID)
 	}
 
 	// Prevent deletion of running jobs
 	if jb.IsRunning() || jb.IsScheduled() {
-		return fmt.Errorf("cannot delete job %s (status: %s) - stop the job first", req.JobUUID, jb.Status)
+		return fmt.Errorf("%w: cannot delete job %s (status: %s) - stop the job first", pkgerrors.ErrJobAlreadyRunning, req.JobUUID, jb.Status)
 	}
 
 	log.Info("deleting job completely", "status", jb.Status, "reason", req.Reason)

--- a/internal/joblet/runtime/resolver.go
+++ b/internal/joblet/runtime/resolver.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 
+	pkgerrors "github.com/ehsaniara/joblet/pkg/errors"
 	"github.com/ehsaniara/joblet/pkg/logger"
 	"github.com/ehsaniara/joblet/pkg/platform"
 	"github.com/ehsaniara/joblet/pkg/semver"
@@ -190,7 +191,7 @@ func (r *Resolver) ResolveRuntime(runtimeSpec string) (*RuntimeConfig, error) {
 	// Find the runtime directory
 	runtimeDir, err := r.FindRuntimeDirectory(runtimeSpec)
 	if err != nil {
-		return nil, fmt.Errorf("runtime not found: %w", err)
+		return nil, fmt.Errorf("%w: %v", pkgerrors.ErrRuntimeNotFound, err)
 	}
 
 	// Load runtime configuration
@@ -350,7 +351,7 @@ func (r *Resolver) FindRuntimeDirectory(spec string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("runtime not found for spec %s", spec)
+	return "", fmt.Errorf("%w: spec %s", pkgerrors.ErrRuntimeNotFound, spec)
 }
 
 // runtimeMatches checks if a runtime config matches a runtime specification
@@ -582,7 +583,7 @@ func (r *Resolver) getRuntimeConfig(runtimeName string) (*RuntimeConfig, error) 
 		}
 	}
 
-	return nil, fmt.Errorf("runtime config not found for %s", runtimeName)
+	return nil, fmt.Errorf("%w: config not found for %s", pkgerrors.ErrRuntimeNotFound, runtimeName)
 }
 
 // inferCUDAVersion attempts to infer CUDA version from runtime name

--- a/internal/joblet/server/error_mapping.go
+++ b/internal/joblet/server/error_mapping.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"errors"
+
+	pkgerrors "github.com/ehsaniara/joblet/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// statusFromError turns a domain error into a gRPC status, picking the code
+// from the wrapped sentinel. If err already has a gRPC status, it passes through.
+// Anything not recognised becomes Internal.
+func statusFromError(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+	if s, ok := status.FromError(err); ok && s.Code() != codes.Unknown {
+		return err
+	}
+	return status.Errorf(codeForError(err), "%s: %v", msg, err)
+}
+
+func codeForError(err error) codes.Code {
+	switch {
+	case errors.Is(err, pkgerrors.ErrJobNotFound),
+		errors.Is(err, pkgerrors.ErrRuntimeNotFound),
+		errors.Is(err, pkgerrors.ErrVolumeNotFound):
+		return codes.NotFound
+	case errors.Is(err, pkgerrors.ErrInvalidJobSpec),
+		errors.Is(err, pkgerrors.ErrInvalidResourceSpec):
+		return codes.InvalidArgument
+	case errors.Is(err, pkgerrors.ErrJobNotRunning),
+		errors.Is(err, pkgerrors.ErrJobAlreadyRunning),
+		errors.Is(err, pkgerrors.ErrVolumeInUse):
+		return codes.FailedPrecondition
+	default:
+		return codes.Internal
+	}
+}

--- a/internal/joblet/server/error_mapping_test.go
+++ b/internal/joblet/server/error_mapping_test.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	pkgerrors "github.com/ehsaniara/joblet/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestStatusFromError_NilReturnsNil(t *testing.T) {
+	assert.Nil(t, statusFromError(nil, "anything"))
+}
+
+func TestStatusFromError_PassesThroughExistingStatus(t *testing.T) {
+	original := status.Error(codes.PermissionDenied, "denied")
+	assert.Equal(t, original, statusFromError(original, "ignored"))
+}
+
+func TestStatusFromError_MapsSentinelsToCodes(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{"job not found", pkgerrors.ErrJobNotFound, codes.NotFound},
+		{"runtime not found", pkgerrors.ErrRuntimeNotFound, codes.NotFound},
+		{"volume not found", pkgerrors.ErrVolumeNotFound, codes.NotFound},
+		{"invalid job spec", pkgerrors.ErrInvalidJobSpec, codes.InvalidArgument},
+		{"invalid resource spec", pkgerrors.ErrInvalidResourceSpec, codes.InvalidArgument},
+		{"job not running", pkgerrors.ErrJobNotRunning, codes.FailedPrecondition},
+		{"job already running", pkgerrors.ErrJobAlreadyRunning, codes.FailedPrecondition},
+		{"volume in use", pkgerrors.ErrVolumeInUse, codes.FailedPrecondition},
+		{"unknown error", errors.New("anything else"), codes.Internal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, ok := status.FromError(statusFromError(tc.err, "op"))
+			assert.True(t, ok)
+			assert.Equal(t, tc.want, s.Code())
+		})
+	}
+}
+
+func TestStatusFromError_UnwrapsSentinelThroughChain(t *testing.T) {
+	wrapped := fmt.Errorf("upstream wrap: %w",
+		fmt.Errorf("%w: job ABCD", pkgerrors.ErrJobNotFound))
+	s, ok := status.FromError(statusFromError(wrapped, "lookup"))
+	assert.True(t, ok)
+	assert.Equal(t, codes.NotFound, s.Code())
+}

--- a/internal/joblet/server/job_service.go
+++ b/internal/joblet/server/job_service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ehsaniara/joblet/internal/joblet/mappers"
 	"github.com/ehsaniara/joblet/internal/joblet/telemetry"
 	persistpb "github.com/ehsaniara/joblet/internal/proto/gen/persist"
+	pkgerrors "github.com/ehsaniara/joblet/pkg/errors"
 	"github.com/ehsaniara/joblet/pkg/logger"
 
 	"google.golang.org/grpc"
@@ -91,7 +92,7 @@ func (s *JobServiceServer) RunJob(ctx context.Context, req *pb.RunJobRequest) (*
 	jobRequest, err := s.convertToJobRequest(req)
 	if err != nil {
 		log.Error("failed to convert request", "error", err)
-		return nil, status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
+		return nil, statusFromError(err, "invalid request")
 	}
 
 	// Log the request (excluding sensitive environment variables)
@@ -116,7 +117,7 @@ func (s *JobServiceServer) RunJob(ctx context.Context, req *pb.RunJobRequest) (*
 	newJob, err := s.joblet.StartJob(ctx, *jobRequest)
 	if err != nil {
 		log.Error("job creation failed", "error", err)
-		return nil, status.Errorf(codes.Internal, "job run failed: %v", err)
+		return nil, statusFromError(err, "job run failed")
 	}
 
 	if req.Schedule != "" {
@@ -138,7 +139,7 @@ func (s *JobServiceServer) RunJob(ctx context.Context, req *pb.RunJobRequest) (*
 // convertToJobRequest converts protobuf request to domain request object
 func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfaces.StartJobRequest, error) {
 	if req.Command == "" {
-		return nil, fmt.Errorf("command is required")
+		return nil, fmt.Errorf("%w: command is required", pkgerrors.ErrInvalidJobSpec)
 	}
 
 	network := req.Network
@@ -360,7 +361,7 @@ func (s *JobServiceServer) StopJob(ctx context.Context, req *pb.StopJobRequest) 
 	err := s.joblet.StopJob(ctx, stopRequest)
 	if err != nil {
 		log.Error("job stop failed", "error", err)
-		return nil, status.Errorf(codes.Internal, "job stop failed: %v", err)
+		return nil, statusFromError(err, "job stop failed")
 	}
 
 	log.Info("job stopped successfully", "job_uuid", stopRequest.JobUUID)
@@ -394,7 +395,7 @@ func (s *JobServiceServer) DeleteJob(ctx context.Context, req *pb.DeleteJobReque
 			Uuid:    deleteRequest.JobUUID,
 			Success: false,
 			Message: err.Error(),
-		}, status.Errorf(codes.Internal, "job deletion failed: %v", err)
+		}, statusFromError(err, "job deletion failed")
 	}
 
 	log.Info("job deletion completed successfully", "job_uuid", deleteRequest.JobUUID)
@@ -429,7 +430,7 @@ func (s *JobServiceServer) DeleteAllJobs(ctx context.Context, req *pb.DeleteAllJ
 			Message:      err.Error(),
 			DeletedCount: 0,
 			SkippedCount: 0,
-		}, status.Errorf(codes.Internal, "bulk job deletion failed: %v", err)
+		}, statusFromError(err, "bulk job deletion failed")
 	}
 
 	log.Info("bulk job deletion completed successfully",


### PR DESCRIPTION
Domain failures (job not found, invalid spec, precondition violations) now propagate from core to the gRPC server with correct status codes instead of collapsing to Internal. 

Adds a centralized statusFromError helper, wraps the relevant producer sites with sentinels from pkg/errors, and routes the job lifecycle handlers through the mapper.