### PR TITLE
drop verifier-less NewGPUService constructor

### DIFF
--- a/internal/joblet/core/execution/gpu_service.go
+++ b/internal/joblet/core/execution/gpu_service.go
@@ -29,16 +29,9 @@ type GPUService struct {
 	logger       *logger.Logger
 }
 
-// NewGPUService creates a new GPU service
-func NewGPUService(gpuManager gpu.GPUManagerInterface, logger *logger.Logger) *GPUService {
-	return &GPUService{
-		gpuManager: gpuManager,
-		logger:     logger.WithField("component", "gpu-service"),
-	}
-}
-
-// NewGPUServiceWithVerifier creates a GPU service with CUDA verification
-func NewGPUServiceWithVerifier(gpuManager gpu.GPUManagerInterface, verifier gpu.CUDAVerifierInterface, logger *logger.Logger) *GPUService {
+// NewGPUService creates a new GPU service. Pass a nil verifier to skip
+// CUDA runtime verification (tests).
+func NewGPUService(gpuManager gpu.GPUManagerInterface, verifier gpu.CUDAVerifierInterface, logger *logger.Logger) *GPUService {
 	return &GPUService{
 		gpuManager:   gpuManager,
 		cudaVerifier: verifier,

--- a/internal/joblet/core/execution/gpu_service_test.go
+++ b/internal/joblet/core/execution/gpu_service_test.go
@@ -18,7 +18,7 @@ func TestGPUService_AllocateGPU_DisabledGPU(t *testing.T) {
 	fakeGPUManager.IsEnabledReturns(false)
 
 	// Create GPU service
-	service := execution.NewGPUService(fakeGPUManager, logger.New())
+	service := execution.NewGPUService(fakeGPUManager, nil, logger.New())
 
 	// Create job with GPU requirement
 	job := &domain.Job{
@@ -50,7 +50,7 @@ func TestGPUService_AllocateGPU_DisabledGPU_NoRequirement(t *testing.T) {
 	fakeGPUManager.IsEnabledReturns(false)
 
 	// Create GPU service
-	service := execution.NewGPUService(fakeGPUManager, logger.New())
+	service := execution.NewGPUService(fakeGPUManager, nil, logger.New())
 
 	// Create job WITHOUT GPU requirement
 	job := &domain.Job{
@@ -84,7 +84,7 @@ func TestGPUService_AllocateGPU_Success(t *testing.T) {
 	fakeGPUManager.AllocateGPUsReturns(expectedAllocation, nil)
 
 	// Create GPU service
-	service := execution.NewGPUService(fakeGPUManager, logger.New())
+	service := execution.NewGPUService(fakeGPUManager, nil, logger.New())
 
 	// Create job with GPU requirement
 	job := &domain.Job{
@@ -140,7 +140,7 @@ func TestGPUService_AllocateGPU_NoGPURequired(t *testing.T) {
 	fakeGPUManager.IsEnabledReturns(true)
 
 	// Create GPU service
-	service := execution.NewGPUService(fakeGPUManager, logger.New())
+	service := execution.NewGPUService(fakeGPUManager, nil, logger.New())
 
 	// Create job without GPU requirement
 	job := &domain.Job{
@@ -175,7 +175,7 @@ func TestGPUService_AllocateGPU_AllocationFailure(t *testing.T) {
 	fakeGPUManager.AllocateGPUsReturns(nil, expectedError)
 
 	// Create GPU service
-	service := execution.NewGPUService(fakeGPUManager, logger.New())
+	service := execution.NewGPUService(fakeGPUManager, nil, logger.New())
 
 	// Create job with GPU requirement
 	job := &domain.Job{
@@ -206,7 +206,7 @@ func TestGPUService_ReleaseGPU_Success(t *testing.T) {
 	fakeGPUManager.ReleaseGPUsReturns(nil)
 
 	// Create GPU service
-	service := execution.NewGPUService(fakeGPUManager, logger.New())
+	service := execution.NewGPUService(fakeGPUManager, nil, logger.New())
 
 	// Release GPU
 	err := service.ReleaseGPU(context.Background(), "test-job")
@@ -232,7 +232,7 @@ func TestGPUService_ReleaseGPU_Disabled(t *testing.T) {
 	fakeGPUManager.IsEnabledReturns(false)
 
 	// Create GPU service
-	service := execution.NewGPUService(fakeGPUManager, logger.New())
+	service := execution.NewGPUService(fakeGPUManager, nil, logger.New())
 
 	// Release GPU
 	err := service.ReleaseGPU(context.Background(), "test-job")
@@ -258,7 +258,7 @@ func TestGPUService_ReleaseGPU_Failure(t *testing.T) {
 	fakeGPUManager.ReleaseGPUsReturns(expectedError)
 
 	// Create GPU service
-	service := execution.NewGPUService(fakeGPUManager, logger.New())
+	service := execution.NewGPUService(fakeGPUManager, nil, logger.New())
 
 	// Release GPU
 	err := service.ReleaseGPU(context.Background(), "test-job")
@@ -277,7 +277,7 @@ func TestGPUService_IsGPUEnabled(t *testing.T) {
 		fakeGPUManager := &gpufakes.FakeGPUManagerInterface{}
 		fakeGPUManager.IsEnabledReturns(true)
 
-		service := execution.NewGPUService(fakeGPUManager, logger.New())
+		service := execution.NewGPUService(fakeGPUManager, nil, logger.New())
 
 		if !service.IsGPUEnabled() {
 			t.Error("Expected GPU to be enabled")
@@ -288,7 +288,7 @@ func TestGPUService_IsGPUEnabled(t *testing.T) {
 		fakeGPUManager := &gpufakes.FakeGPUManagerInterface{}
 		fakeGPUManager.IsEnabledReturns(false)
 
-		service := execution.NewGPUService(fakeGPUManager, logger.New())
+		service := execution.NewGPUService(fakeGPUManager, nil, logger.New())
 
 		if service.IsGPUEnabled() {
 			t.Error("Expected GPU to be disabled")

--- a/internal/joblet/core/job_executor.go
+++ b/internal/joblet/core/job_executor.go
@@ -95,7 +95,7 @@ func NewExecutionEngineV2(
 
 	// Create GPU service with CUDA verification
 	cudaVerifier := gpu.NewCUDAVerifier()
-	gpuService := execution.NewGPUServiceWithVerifier(gpuManager, cudaVerifier, logger)
+	gpuService := execution.NewGPUService(gpuManager, cudaVerifier, logger)
 
 	// Create execution coordinator
 	coordinator := execution.NewExecutionCoordinator(


### PR DESCRIPTION
`execution.GPUService` had two constructors: `NewGPUService` (no CUDA verifier) and `NewGPUServiceWithVerifier`. Only the verifier variant is used in production caller picking the more obvious name would silently disable CUDA verification, since AllocateGPU guards with `if cudaVerifier != nil`.