### PR TITLE
docs: remove leftover workflow references

### DIFF
--- a/docs/ADMIN_MIGRATION.md
+++ b/docs/ADMIN_MIGRATION.md
@@ -429,7 +429,6 @@ JOBLET_NODE=default
 - Volume management
 - Network configuration
 - Runtime management
-- Workflow visualization
 
 ### B. Dependencies to Migrate
 

--- a/docs/GPU_SUPPORT.md
+++ b/docs/GPU_SUPPORT.md
@@ -59,59 +59,6 @@ rnx job run --gpu=2 --gpu-memory=8GB python multi_gpu_training.py
 rnx job run --gpu=1 --max-cpu=400 --max-memory=16384 python hybrid_workload.py
 ```
 
-## Workflow Configuration with GPU Resources
-
-GPU resource requirements can be declaratively specified in workflow definitions:
-
-```yaml
-# ml-training-pipeline.yaml
-jobs:
-  data-preprocessing:
-    command: "python3"
-    args: ["preprocess.py"]
-    runtime: "python-3.11-ml"
-    resources:
-      max_memory: 4096
-      max_cpu: 200
-
-  model-training:
-    command: "python3"
-    args: ["train.py", "--epochs", "100"]
-    runtime: "python-3.11-ml"
-    requires:
-      - data-preprocessing: "COMPLETED"
-    resources:
-      max_memory: 16384
-      max_cpu: 800
-      gpu_count: 2          # Request 2 GPUs
-      gpu_memory_mb: 8192   # 8GB minimum per GPU
-
-  model-evaluation:
-    command: "python3"
-    args: ["evaluate.py"]
-    runtime: "python-3.11-ml"
-    requires:
-      - model-training: "COMPLETED"
-    resources:
-      max_memory: 8192
-      gpu_count: 1
-      gpu_memory_mb: 4096
-```
-
-The `requires` fields define a dependency DAG — each stage starts only once its
-predecessor reaches `COMPLETED`:
-
-```mermaid
-flowchart LR
-    A["data-preprocessing<br/>CPU 200% · 4 GB RAM"] -->|COMPLETED| B["model-training<br/>2× GPU · 8 GB/GPU<br/>CPU 800% · 16 GB RAM"]
-    B -->|COMPLETED| C["model-evaluation<br/>1× GPU · 4 GB/GPU<br/>8 GB RAM"]
-```
-
-```bash
-# Run the GPU-enabled workflow
-rnx workflow run ml-training-pipeline.yaml
-```
-
 ## GPU Runtime Environment
 
 ### CUDA Runtime Integration
@@ -220,7 +167,6 @@ rnx job run --gpu=1 --gpu-memory=8GB \
 1. **Pre-validate Memory Requirements**: Profile model memory consumption before production deployment
 2. **Right-size GPU Allocation**: Request only necessary GPU resources to maximize cluster efficiency
 3. **Balance Resource Profiles**: Configure complementary CPU and memory limits for optimal performance
-4. **Leverage Workflow Orchestration**: Design pipelines that efficiently sequence GPU and CPU workloads
 
 ### Resource Allocation Patterns
 
@@ -240,9 +186,6 @@ rnx job run --gpu=2 --gpu-memory=8GB --max-memory=16384 --max-cpu=800 \
 # Separate preprocessing (CPU-only) from training (GPU)
 rnx job run --max-cpu=400 --max-memory=8192 python preprocess.py
 rnx job run --gpu=1 --gpu-memory=8GB python train.py
-
-# Use workflows for complex pipelines
-rnx workflow run ml-pipeline.yaml
 ```
 
 ### Environment-Specific Configuration

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -330,9 +330,11 @@ rnx job delete <job-id>
 Planned features for future releases:
 
 1. **Cron-style recurring schedules**
-2. **Job orchestration layer** with leader election
-3. **Cross-node job reassignment** on failure
-4. **Job dependencies and workflows**
+2. **Cross-node job reassignment** on failure
+
+> Job dependencies and multi-job orchestration are intentionally out of scope for the executor — they are handled by a
+> separate workflow-orchestration project that builds on joblet's Job API (see
+> [ADR-013](adr/013-extract-workflow-to-separate-project.md)).
 
 ## Best Practices
 

--- a/docs/adr/008-gpu-support-architecture.md
+++ b/docs/adr/008-gpu-support-architecture.md
@@ -11,8 +11,11 @@
 - CUDA environment detection and mounting: Implemented
 - RNX CLI integration with `--gpu` and `--gpu-memory` flags: Implemented
 - JSON API support: Implemented
-- Workflow GPU configuration: Implemented
 - Comprehensive testing framework: Implemented
+
+> **Note**: GPU configuration in workflow definitions was removed when workflow orchestration was extracted to a
+> separate project (see [ADR-013](013-extract-workflow-to-separate-project.md)). Joblet exposes GPU allocation only
+> through the single-job `rnx job run --gpu` / `--gpu-memory` flags.
 
 ## Context
 

--- a/docs/adr/013-extract-workflow-to-separate-project.md
+++ b/docs/adr/013-extract-workflow-to-separate-project.md
@@ -72,8 +72,8 @@ Several forces are pushing us toward extraction:
 4. **Deployment flexibility**: Some users want joblet as a lightweight job executor without workflow overhead. Others
    want sophisticated orchestration. Currently, everyone gets both.
 
-5. **Alternative orchestrators**: Users might prefer existing workflow tools (Temporal, Airflow, Argo) while still
-   using joblet for execution. The current coupling makes this awkward.
+5. **Orchestration flexibility**: Some users want to drive joblet from their own orchestration layer while using
+   joblet purely for execution. The current coupling makes this awkward.
 
 ## Decision
 
@@ -178,8 +178,8 @@ require joblet updates. Version coupling is eliminated.
 **Deployment flexibility**: Run orchestrator centrally while distributing joblet agents. Or run both together.
 Or skip orchestrator entirely for simple use cases.
 
-**Alternative orchestrators**: Users can now easily use Temporal, Airflow, or Argo Workflows while keeping joblet
-for execution. Joblet becomes a universal job executor.
+**Universal executor**: With orchestration decoupled, joblet becomes a universal job executor that any
+orchestration layer can drive through its gRPC Job API.
 
 **Better testing**: Each project has focused test suites. Workflow integration tests use the real gRPC API,
 catching interface issues early.
@@ -216,12 +216,10 @@ YAML format, provide migration scripts.
 - Geographic distribution
 - Failure domain isolation
 
-**Pluggable backends**: The orchestrator could support multiple execution backends:
-
-- Joblet (primary)
-- Docker/Podman (alternative)
-- Kubernetes (for hybrid deployments)
-- SSH (for legacy systems)
+**Unified execution backend**: The orchestrator targets joblet as its execution backend everywhere — local,
+cloud, and multi-node. Because joblet provides isolation, resource limits, GPU allocation, and networking natively
+through Linux kernel primitives, the orchestrator gets one consistent execution surface across environments without
+having to special-case container runtimes or remote-shell transports.
 
 **Workflow-as-Code**: Without being tied to joblet's release cycle, the orchestrator can experiment with:
 
@@ -246,12 +244,14 @@ Build orchestrator as a plugin loaded at runtime. Single binary, optional capabi
 **Rejected because**: Go's plugin system is limited and brittle. Versioning plugins with the host is complex.
 Doesn't help with independent deployment.
 
-### Use Existing Orchestrator (Temporal/Airflow)
+### Adopt a Third-Party Orchestrator
 
-Don't build our own orchestrator. Document how to use existing tools with joblet.
+Don't build our own orchestrator. Document how to drive joblet from an off-the-shelf one instead.
 
-**Considered and partially accepted**: This is complementary. By extracting workflows, we make it *easier* to use
-existing orchestrators. Our orchestrator becomes one option among many, not a requirement.
+**Rejected**: A first-party orchestrator that speaks joblet's Job API natively gives users a cohesive, supported
+experience out of the box. Extracting workflows into `joblet-orchestrator` still keeps the Job API open, so teams
+with an existing orchestration layer can integrate — but joblet ships a complete solution rather than deferring to
+external tooling.
 
 ## Implementation Notes
 

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -162,19 +162,6 @@ rnx runtime build ./examples/java-21/runtime.yaml
 rnx runtime list
 ```
 
-### Create Workflows
-
-Build your own job pipelines.
-
-```yaml
-version: "3.0"
-jobs:
-  my-job:
-    command: "python3"
-    args: [ "script.py" ]
-    runtime: "python-3.11-ml"
-```
-
 ---
 
 ## Which Guide Should I Use?

--- a/examples/log-streaming/run_demo.sh
+++ b/examples/log-streaming/run_demo.sh
@@ -88,11 +88,11 @@ run_demo_job() {
     echo_header "Demo: $description"
     
     echo_info "Starting job: $job_name"
-    echo_command "rnx workflow run jobs.yaml
-    
+    echo_command "rnx job run --upload=high_frequency_logger.py python3 high_frequency_logger.py"
+
     # Start the job and capture the job ID
     local job_output
-    job_output=$(rnx workflow run jobs.yaml 2>&1)
+    job_output=$(rnx job run --upload=high_frequency_logger.py python3 high_frequency_logger.py 2>&1)
     local job_id
     job_id=$(echo "$job_output" | grep -E "Job [A-Za-z0-9-]+ started" | awk '{print $2}' || echo "")
     
@@ -152,9 +152,9 @@ demo_concurrent_logging() {
     
     # Start multiple jobs concurrently
     for i in {1..3}; do
-        echo_command "rnx workflow run jobs.yaml (job $i)"
+        echo_command "rnx job run --upload=high_frequency_logger.py python3 high_frequency_logger.py (job $i)"
         local job_output
-        job_output=$(rnx workflow run jobs.yaml 2>&1)
+        job_output=$(rnx job run --upload=high_frequency_logger.py python3 high_frequency_logger.py 2>&1)
         local job_id
         job_id=$(echo "$job_output" | grep -E "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" | head -1 | awk '{print $1}' || echo "")
         
@@ -279,7 +279,7 @@ echo_header "🚀 Next Steps"
 echo_info "Try these commands to explore the async log system further:"
 echo
 echo_command "# Run custom logging patterns"
-echo_command "START_NUM=5000 END_NUM=6000 INTERVAL=0.05 rnx workflow run jobs.yaml
+echo_command "rnx job run --upload=high_frequency_logger.py --env=START_NUM=5000 --env=END_NUM=6000 --env=INTERVAL=0.05 python3 high_frequency_logger.py"
 echo
 echo_command "# Monitor system performance during logging"
 echo_command "rnx monitor status  # View system metrics in real-time"
@@ -287,8 +287,8 @@ echo
 echo_command "# View all current jobs"
 echo_command "rnx job list"
 echo
-echo_command "# Run concurrent workflow"
-echo_command "rnx workflow run concurrent-logging.yaml"
+echo_command "# Run another logging job concurrently"
+echo_command "rnx job run --upload=high_frequency_logger.py python3 high_frequency_logger.py"
 
 echo_success "🎉 Async log system demo completed successfully!"
 echo_info "The rate-decoupled async architecture ensures your jobs never wait for disk I/O,"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -15,7 +15,6 @@ team-configurable parameters.
 ./run_tests.sh -t network      # Network configuration tests
 ./run_tests.sh -t schedule     # Job scheduling tests
 ./run_tests.sh -t volume       # Volume management tests
-./run_tests.sh -t workflow     # Workflow dependency tests
 
 # ⚡ Development/debugging (skip build - use cautiously)
 ./run_tests.sh --no-build      # Skip build for rapid test iteration
@@ -170,7 +169,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/test-config.sh"
 
 run_rnx job list                          # Configurable rnx command
-wait_for_job_completion "$workflow"   # Built-in timeout handling
+wait_for_job_completion "$job_id"     # Built-in timeout handling
 cleanup_test_resources               # Auto cleanup
 log_test_result "Test" "PASSED"      # Consistent logging
 ```
@@ -186,7 +185,7 @@ tests/e2e/
 ├── network/                # Network-specific tests
 │   ├── run-all-network-tests.sh
 │   ├── test-*.sh          # Individual network tests
-│   └── *.yaml            # Test workflows
+│   └── *.yaml            # Test configs
 └── volume/                # Volume tests (future)
 ```
 

--- a/tests/e2e/tests/09_gpu_test.sh
+++ b/tests/e2e/tests/09_gpu_test.sh
@@ -197,56 +197,6 @@ test_cuda_environment() {
     fi
 }
 
-# Test workflow with GPU jobs
-test_gpu_workflow() {
-    # Create a simple GPU workflow
-    local workflow_file="/tmp/gpu_test_workflow.yaml"
-    cat > "$workflow_file" << 'EOF'
-name: "GPU Test Workflow"
-description: "Test workflow with GPU allocation"
-
-jobs:
-  gpu-preprocessing:
-    command: "echo"
-    args: ["Preprocessing with GPU"]
-    resources:
-      gpu_count: 1
-      gpu_memory_mb: 2048
-      max_memory: 1024
-
-  gpu-training:
-    command: "echo"
-    args: ["Training with GPU"]
-    requires:
-      - gpu-preprocessing: "COMPLETED"
-    resources:
-      gpu_count: 1
-      gpu_memory_mb: 4096
-      max_memory: 2048
-EOF
-
-    # Run the workflow
-    local workflow_output=$("$RNX_BINARY" --json workflow run "$workflow_file" 2>&1)
-    local exit_code=$?
-
-    # Clean up workflow file
-    rm -f "$workflow_file"
-
-    if [[ $exit_code -ne 0 ]]; then
-        if echo "$workflow_output" | grep -q -i "gpu.*not.*available\|gpu.*disabled"; then
-            echo "    ${YELLOW}GPU workflow test skipped (GPU not available)${NC}"
-            return 0
-        else
-            echo "    ${RED}GPU workflow failed${NC}"
-            echo "    ${RED}Output: $workflow_output${NC}"
-            return 1
-        fi
-    fi
-
-    echo "    ${GREEN}GPU workflow executed successfully${NC}"
-    return 0
-}
-
 # ============================================
 # Test Suite Execution
 # ============================================
@@ -271,9 +221,6 @@ main() {
     run_test "Basic GPU job execution" test_gpu_job_execution
     run_test "Multi-GPU allocation" test_multi_gpu_allocation
     run_test "CUDA environment variables" test_cuda_environment
-
-    test_section "GPU Workflows"
-    run_test "GPU workflow execution" test_gpu_workflow
 
     # Clean up
     cleanup_test_artifacts


### PR DESCRIPTION
Follow-up to the workflow extraction (ADR-013). Removes dead references to the removed `rnx workflow` feature