### PR TITLE
fix: validate runtime suitability at job submission (#271)

### DIFF
--- a/internal/joblet/core/filesystem/isolator.go
+++ b/internal/joblet/core/filesystem/isolator.go
@@ -1147,10 +1147,13 @@ func (f *JobFilesystem) mountRuntimeWithManager(runtimeBasePath string) error {
 		Environment map[string]string `yaml:"environment"`
 	}
 
-	// Use runtime resolver to find the actual runtime directory
-	// This handles versioned runtimes like python-3.11@1.3.1 -> /opt/joblet/runtimes/python-3.11/1.3.1/
+	// Resolve the runtime spec to its directory, handling versioned runtimes
+	// like python-3.11@1.3.1 -> /opt/joblet/runtimes/python-3.11/1.3.1/.
+	// This validates the runtime even though submission already did: scheduled
+	// jobs can run long after submission, and the runtime may be gone or
+	// changed by then.
 	runtimeResolver := runtime.NewResolver(runtimeBasePath, f.platform)
-	runtimeDir, err := runtimeResolver.FindRuntimeDirectory(f.Runtime)
+	runtimeDir, _, err := runtimeResolver.ResolveRuntimeDirectory(f.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to resolve runtime path for %s: %w", f.Runtime, err)
 	}

--- a/internal/joblet/gpu/cuda.go
+++ b/internal/joblet/gpu/cuda.go
@@ -354,7 +354,7 @@ func (c *CUDADetector) extractVersionFromPath(path string) (CUDAVersion, error) 
 	}
 
 	versionStr := strings.TrimPrefix(base, "cuda-")
-	return c.parseVersionString(versionStr)
+	return ParseCUDAVersion(versionStr)
 }
 
 // getVersionFromNvcc gets version by running nvcc --version
@@ -440,8 +440,8 @@ func (c *CUDADetector) parseVersionFromContent(content string) (CUDAVersion, err
 	return CUDAVersion{}, fmt.Errorf("could not parse version from content")
 }
 
-// parseVersionString parses a version string like "12.1"
-func (c *CUDADetector) parseVersionString(versionStr string) (CUDAVersion, error) {
+// ParseCUDAVersion parses a version string like "12.1" into a CUDAVersion
+func ParseCUDAVersion(versionStr string) (CUDAVersion, error) {
 	parts := strings.Split(versionStr, ".")
 	if len(parts) < 2 {
 		return CUDAVersion{}, fmt.Errorf("invalid version format: %s", versionStr)

--- a/internal/joblet/gpu/cuda_test.go
+++ b/internal/joblet/gpu/cuda_test.go
@@ -60,8 +60,6 @@ func TestCUDAVersion_IsCompatible(t *testing.T) {
 }
 
 func TestParseVersionString(t *testing.T) {
-	detector := &CUDADetector{}
-
 	tests := []struct {
 		name        string
 		versionStr  string
@@ -97,7 +95,7 @@ func TestParseVersionString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			version, err := detector.parseVersionString(tt.versionStr)
+			version, err := ParseCUDAVersion(tt.versionStr)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {

--- a/internal/joblet/runtime/resolver.go
+++ b/internal/joblet/runtime/resolver.go
@@ -188,25 +188,31 @@ func (r *Resolver) ResolveRuntime(runtimeSpec string) (*RuntimeConfig, error) {
 		return nil, nil
 	}
 
-	// Find the runtime directory
+	_, config, err := r.ResolveRuntimeDirectory(runtimeSpec)
+	return config, err
+}
+
+// ResolveRuntimeDirectory finds the directory for a runtime specification,
+// loads its runtime.yml, and validates it against this node (architecture
+// compatibility). Callers that only need one of the results can discard the
+// other; the config is always loaded and validated before either is returned.
+func (r *Resolver) ResolveRuntimeDirectory(runtimeSpec string) (string, *RuntimeConfig, error) {
 	runtimeDir, err := r.FindRuntimeDirectory(runtimeSpec)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", pkgerrors.ErrRuntimeNotFound, err)
+		return "", nil, fmt.Errorf("%w: %v", pkgerrors.ErrRuntimeNotFound, err)
 	}
 
-	// Load runtime configuration
 	configPath := filepath.Join(runtimeDir, "runtime.yml")
 	config, err := r.loadRuntimeConfig(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load runtime config: %w", err)
+		return "", nil, fmt.Errorf("failed to load runtime config: %w", err)
 	}
 
-	// Basic validation
 	if err := r.validateRuntime(config); err != nil {
-		return nil, fmt.Errorf("runtime validation failed: %w", err)
+		return "", nil, fmt.Errorf("runtime validation failed: %w", err)
 	}
 
-	return config, nil
+	return runtimeDir, config, nil
 }
 
 // FindRuntimeDirectory finds the directory for a runtime specification (fully generic)
@@ -485,7 +491,7 @@ func (r *Resolver) validateRuntime(config *RuntimeConfig) error {
 		currentArch := runtime.GOARCH
 		archCompatible := false
 		for _, arch := range config.Requirements.Architectures {
-			if arch == currentArch || arch == "x86_64" && currentArch == "amd64" {
+			if normalizeArch(arch) == currentArch {
 				archCompatible = true
 				break
 			}
@@ -497,6 +503,18 @@ func (r *Resolver) validateRuntime(config *RuntimeConfig) error {
 	}
 
 	return nil
+}
+
+// normalizeArch maps common uname-style architecture names to Go's GOARCH values
+func normalizeArch(arch string) string {
+	switch arch {
+	case "x86_64":
+		return "amd64"
+	case "aarch64":
+		return "arm64"
+	default:
+		return arch
+	}
 }
 
 // IsGPUEnabled checks if a runtime has GPU support based on its name and tags

--- a/internal/joblet/runtime/resolver_test.go
+++ b/internal/joblet/runtime/resolver_test.go
@@ -684,3 +684,64 @@ mounts: []
 		require.NoError(b, err)
 	}
 }
+
+func TestResolver_ResolveRuntimeDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	runtimesPath := filepath.Join(tempDir, "runtimes")
+	runtimeDir := filepath.Join(runtimesPath, "python-3.11")
+	require.NoError(t, os.MkdirAll(runtimeDir, 0755))
+
+	config := `name: python-3.11
+language: python
+version: "1.0.0"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(runtimeDir, "runtime.yml"), []byte(config), 0644))
+
+	resolver := NewResolver(runtimesPath, platform.NewPlatform())
+
+	dir, cfg, err := resolver.ResolveRuntimeDirectory("python-3.11")
+	require.NoError(t, err)
+	assert.Equal(t, runtimeDir, dir)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "python-3.11", cfg.Name)
+}
+
+func TestResolver_ResolveRuntimeDirectory_NotFound(t *testing.T) {
+	tempDir := t.TempDir()
+	runtimesPath := filepath.Join(tempDir, "runtimes")
+	require.NoError(t, os.MkdirAll(runtimesPath, 0755))
+
+	resolver := NewResolver(runtimesPath, platform.NewPlatform())
+
+	_, _, err := resolver.ResolveRuntimeDirectory("does-not-exist")
+	require.Error(t, err)
+}
+
+func TestResolver_ResolveRuntimeDirectory_IncompatibleArchitecture(t *testing.T) {
+	tempDir := t.TempDir()
+	runtimesPath := filepath.Join(tempDir, "runtimes")
+	runtimeDir := filepath.Join(runtimesPath, "python-3.11")
+	require.NoError(t, os.MkdirAll(runtimeDir, 0755))
+
+	config := `name: python-3.11
+language: python
+version: "1.0.0"
+requirements:
+  architectures: ["mips64"]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(runtimeDir, "runtime.yml"), []byte(config), 0644))
+
+	resolver := NewResolver(runtimesPath, platform.NewPlatform())
+
+	_, _, err := resolver.ResolveRuntimeDirectory("python-3.11")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "architecture")
+}
+
+func TestNormalizeArch(t *testing.T) {
+	assert.Equal(t, "amd64", normalizeArch("x86_64"))
+	assert.Equal(t, "arm64", normalizeArch("aarch64"))
+	assert.Equal(t, "amd64", normalizeArch("amd64"))
+	assert.Equal(t, "arm64", normalizeArch("arm64"))
+	assert.Equal(t, "riscv64", normalizeArch("riscv64"))
+}

--- a/internal/joblet/server/grpc_server.go
+++ b/internal/joblet/server/grpc_server.go
@@ -69,7 +69,7 @@ func StartGRPCServer(jobStore adapters.JobStorer, telemetryCollector *telemetry.
 	}
 
 	// Create job service (lean, no workflow orchestration)
-	jobService := NewJobServiceServer(auth, jobStore, telemetryCollector, joblet, persistClient)
+	jobService := NewJobServiceServer(auth, jobStore, telemetryCollector, joblet, persistClient, cfg.Runtime.BasePath, platform)
 	pb.RegisterJobServiceServer(grpcServer, jobService)
 
 	// Create and register network service

--- a/internal/joblet/server/job_service.go
+++ b/internal/joblet/server/job_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	pb "github.com/ehsaniara/joblet-proto/v2/gen"
@@ -12,11 +11,14 @@ import (
 	auth2 "github.com/ehsaniara/joblet/internal/joblet/auth"
 	"github.com/ehsaniara/joblet/internal/joblet/core/interfaces"
 	"github.com/ehsaniara/joblet/internal/joblet/domain"
+	"github.com/ehsaniara/joblet/internal/joblet/gpu"
 	"github.com/ehsaniara/joblet/internal/joblet/mappers"
+	jobletruntime "github.com/ehsaniara/joblet/internal/joblet/runtime"
 	"github.com/ehsaniara/joblet/internal/joblet/telemetry"
 	persistpb "github.com/ehsaniara/joblet/internal/proto/gen/persist"
 	pkgerrors "github.com/ehsaniara/joblet/pkg/errors"
 	"github.com/ehsaniara/joblet/pkg/logger"
+	"github.com/ehsaniara/joblet/pkg/platform"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -38,17 +40,21 @@ type JobServiceServer struct {
 	telemetryCollector *telemetry.Collector
 	joblet             interfaces.Joblet
 	persistClient      persistpb.PersistServiceClient
+	runtimeResolver    *jobletruntime.Resolver
+	cudaDetector       *gpu.CUDADetector
 	logger             *logger.Logger
 }
 
 // NewJobServiceServer creates a new gRPC service server for job operations.
-func NewJobServiceServer(auth auth2.GRPCAuthorization, jobStore adapters.JobStorer, telemetryCollector *telemetry.Collector, joblet interfaces.Joblet, persistClient persistpb.PersistServiceClient) *JobServiceServer {
+func NewJobServiceServer(auth auth2.GRPCAuthorization, jobStore adapters.JobStorer, telemetryCollector *telemetry.Collector, joblet interfaces.Joblet, persistClient persistpb.PersistServiceClient, runtimesBasePath string, platform platform.Platform) *JobServiceServer {
 	return &JobServiceServer{
 		auth:               auth,
 		jobStore:           jobStore,
 		telemetryCollector: telemetryCollector,
 		joblet:             joblet,
 		persistClient:      persistClient,
+		runtimeResolver:    jobletruntime.NewResolver(runtimesBasePath, platform),
+		cudaDetector:       gpu.NewCUDADetector(platform),
 		logger:             logger.WithField("component", "job-grpc"),
 	}
 }
@@ -194,6 +200,8 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 		Environment:       req.Environment,
 		SecretEnvironment: req.SecretEnvironment,
 		JobType:           jobType,
+		GPUCount:          req.GpuCount,
+		GPUMemoryMB:       int64(req.GpuMemoryMb),
 		Timeout:           req.Timeout,
 	}
 
@@ -215,6 +223,9 @@ func (s *JobServiceServer) validateJobRequest(req *interfaces.StartJobRequest) e
 	if req.Resources.MaxIOBPS < 0 {
 		return fmt.Errorf("maxIOBPS cannot be negative")
 	}
+	if req.GPUCount < 0 {
+		return fmt.Errorf("gpuCount cannot be negative")
+	}
 
 	validNetworks := map[string]bool{
 		"bridge": true,
@@ -232,7 +243,7 @@ func (s *JobServiceServer) validateJobRequest(req *interfaces.StartJobRequest) e
 	}
 
 	if req.Runtime != "" {
-		if err := s.validateRuntime(req.Runtime); err != nil {
+		if err := s.validateRuntime(req); err != nil {
 			return fmt.Errorf("invalid runtime: %w", err)
 		}
 	}
@@ -240,27 +251,28 @@ func (s *JobServiceServer) validateJobRequest(req *interfaces.StartJobRequest) e
 	return nil
 }
 
-// validateRuntime validates the runtime specification
-func (s *JobServiceServer) validateRuntime(runtimeSpec string) error {
-	if runtimeSpec == "" {
-		return fmt.Errorf("runtime specification cannot be empty")
+// validateRuntime resolves the runtime specification and validates it against
+// this node: the runtime must exist on disk, be compatible with the node's
+// architecture, and its GPU/CUDA requirements from runtime.yml must be
+// satisfiable by the job request. The filesystem isolator validates again at
+// launch, since a scheduled job's runtime can be removed before it runs.
+func (s *JobServiceServer) validateRuntime(req *interfaces.StartJobRequest) error {
+	config, err := s.runtimeResolver.ResolveRuntime(req.Runtime)
+	if err != nil {
+		return err
 	}
 
-	if strings.Contains(runtimeSpec, ":") {
-		parts := strings.Split(runtimeSpec, ":")
-		if len(parts) != 2 {
-			return fmt.Errorf("invalid runtime format: expected 'language:version', got '%s'", runtimeSpec)
+	if config.Requirements.GPU && req.GPUCount == 0 {
+		return fmt.Errorf("runtime %s requires a GPU but the job does not request any", req.Runtime)
+	}
+
+	if req.GPUCount > 0 && config.Requirements.CUDAVersion != "" {
+		required, err := gpu.ParseCUDAVersion(config.Requirements.CUDAVersion)
+		if err != nil {
+			return fmt.Errorf("runtime %s declares invalid cuda_version %q: %w", req.Runtime, config.Requirements.CUDAVersion, err)
 		}
-		if parts[0] == "" || parts[1] == "" {
-			return fmt.Errorf("runtime language and version cannot be empty")
-		}
-	} else {
-		parts := strings.Split(runtimeSpec, "-")
-		if len(parts) < 2 {
-			return fmt.Errorf("invalid runtime format: expected 'language-version[-tags]', got '%s'", runtimeSpec)
-		}
-		if parts[0] == "" || parts[1] == "" {
-			return fmt.Errorf("runtime language and version cannot be empty")
+		if _, err := s.cudaDetector.FindCompatibleCUDA(required); err != nil {
+			return fmt.Errorf("runtime %s requires CUDA %s: %w", req.Runtime, config.Requirements.CUDAVersion, err)
 		}
 	}
 

--- a/internal/joblet/server/job_service_validation_test.go
+++ b/internal/joblet/server/job_service_validation_test.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ehsaniara/joblet/internal/joblet/core/interfaces"
+	"github.com/ehsaniara/joblet/internal/joblet/gpu"
+	jobletruntime "github.com/ehsaniara/joblet/internal/joblet/runtime"
+	pkgerrors "github.com/ehsaniara/joblet/pkg/errors"
+	"github.com/ehsaniara/joblet/pkg/logger"
+	"github.com/ehsaniara/joblet/pkg/platform"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestRuntime creates <base>/<name>/runtime.yml with the given content
+func writeTestRuntime(t *testing.T, basePath, name, yml string) {
+	t.Helper()
+	dir := filepath.Join(basePath, name)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "runtime.yml"), []byte(yml), 0644))
+}
+
+func newTestJobService(runtimesPath string) *JobServiceServer {
+	p := platform.NewPlatform()
+	return &JobServiceServer{
+		runtimeResolver: jobletruntime.NewResolver(runtimesPath, p),
+		cudaDetector:    gpu.NewCUDADetector(p),
+		logger:          logger.WithField("component", "job-grpc-test"),
+	}
+}
+
+func TestValidateRuntime_NotFoundRejectedAtSubmission(t *testing.T) {
+	s := newTestJobService(t.TempDir())
+
+	err := s.validateJobRequest(&interfaces.StartJobRequest{Runtime: "python-3.99"})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, pkgerrors.ErrRuntimeNotFound), "expected ErrRuntimeNotFound, got: %v", err)
+}
+
+func TestValidateRuntime_ExistingRuntimeAccepted(t *testing.T) {
+	base := t.TempDir()
+	writeTestRuntime(t, base, "python-3.11", `name: python-3.11
+language: python
+version: "1.0.0"
+`)
+	s := newTestJobService(base)
+
+	err := s.validateJobRequest(&interfaces.StartJobRequest{Runtime: "python-3.11"})
+	assert.NoError(t, err)
+}
+
+func TestValidateRuntime_ColonSpecNotResolvable(t *testing.T) {
+	// Runtime directories are looked up by name[@version]; a colon-form spec
+	// never matches one, so submission rejects it as not found.
+	base := t.TempDir()
+	writeTestRuntime(t, base, "python-3.11", `name: python-3.11
+language: python
+version: "1.0.0"
+`)
+	s := newTestJobService(base)
+
+	err := s.validateJobRequest(&interfaces.StartJobRequest{Runtime: "python:3.11"})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, pkgerrors.ErrRuntimeNotFound), "expected ErrRuntimeNotFound, got: %v", err)
+}
+
+func TestValidateRuntime_IncompatibleArchitectureRejected(t *testing.T) {
+	base := t.TempDir()
+	writeTestRuntime(t, base, "python-3.11", `name: python-3.11
+language: python
+version: "1.0.0"
+requirements:
+  architectures: ["mips64"]
+`)
+	s := newTestJobService(base)
+
+	err := s.validateJobRequest(&interfaces.StartJobRequest{Runtime: "python-3.11"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "architecture")
+}
+
+func TestValidateRuntime_UnameStyleArchitectureAccepted(t *testing.T) {
+	// x86_64/aarch64 (uname style) must match Go's amd64/arm64
+	base := t.TempDir()
+	writeTestRuntime(t, base, "python-3.11", `name: python-3.11
+language: python
+version: "1.0.0"
+requirements:
+  architectures: ["x86_64", "aarch64"]
+`)
+	s := newTestJobService(base)
+
+	err := s.validateJobRequest(&interfaces.StartJobRequest{Runtime: "python-3.11"})
+	assert.NoError(t, err)
+}
+
+func TestValidateRuntime_GPURequiredButNotRequested(t *testing.T) {
+	base := t.TempDir()
+	writeTestRuntime(t, base, "python-3.11-gpu", `name: python-3.11-gpu
+language: python
+version: "1.0.0"
+requirements:
+  gpu: true
+`)
+	s := newTestJobService(base)
+
+	err := s.validateJobRequest(&interfaces.StartJobRequest{Runtime: "python-3.11-gpu"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a GPU")
+
+	err = s.validateJobRequest(&interfaces.StartJobRequest{Runtime: "python-3.11-gpu", GPUCount: 1})
+	assert.NoError(t, err)
+}
+
+func TestValidateRuntime_CUDARequirementUnsatisfiable(t *testing.T) {
+	base := t.TempDir()
+	writeTestRuntime(t, base, "python-3.11-gpu", `name: python-3.11-gpu
+language: python
+version: "1.0.0"
+requirements:
+  gpu: true
+  cuda_version: "99.9"
+`)
+	s := newTestJobService(base)
+
+	err := s.validateJobRequest(&interfaces.StartJobRequest{Runtime: "python-3.11-gpu", GPUCount: 1})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CUDA")
+}
+
+func TestValidateJobRequest_NegativeGPUCount(t *testing.T) {
+	s := newTestJobService(t.TempDir())
+
+	err := s.validateJobRequest(&interfaces.StartJobRequest{GPUCount: -1})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gpuCount")
+}


### PR DESCRIPTION
Fixes #271

Joblet accepted misconfigured job submissions and only failed later during sandbox setup, inside the cloned child process. This moves runtime suitability checks to submission time and closes the gaps between the three validation
paths.

## Changes

- **Existence at submission** — `JobServiceServer.validateRuntime` now resolves the runtime spec on disk via the runtime resolver instead of format-only string checks. Unknown runtimes are rejected immediately with gRPC `NotFound`. This also rejects colon-form specs (`python:3.11`) early: the launch path looks runtimes up by `name[@version]`, so those could never resolve anyway.
- **Architecture on the launch path** — new `Resolver.ResolveRuntimeDirectory` finds the directory, loads `runtime.yml`, and validates architecture compatibility in one step. Both submission and the filesystem isolator's mount path use it, so scheduled jobs are re-validated at launch (a runtime can be removed between submission and execution). Also normalizes
  uname-style arch names (`x86_64`/`aarch64`) to GOARCH values.
- **GPU/CUDA requirements enforced** — `requirements.gpu: true` runtimes now reject jobs that request zero GPUs, and `cuda_version` is checked against detected host CUDA installations at submission (wires up the previously unused `FindCompatibleCUDA` machinery; `ParseCUDAVersion` is now exported).
- **Dropped GPU fields fixed** — `convertToJobRequest` silently discarded `GpuCount`/`GpuMemoryMb`, so GPU requests through `JobService.RunJob` never reached allocation. They are now mapped, with a negative-count guard.
  Behavior change: `--gpu N` requests that previously no-opped will now actually allocate (or fail if GPU support is disabled).