### PR TITLE
four-role authorization, fail-fast config, streaming reliability, and local pre-PR pipeline

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,32 @@
+# Compatibility
+
+Joblet (and the **RNX** CLI it ships) speaks the `joblet-proto` gRPC contract.
+The **proto major** is the compatibility boundary: proto **v1.x** and **v2.x**
+do **not** interoperate. Every client must target the same proto major as the
+running server. Release versions are tracked by **git tag**; treat the tag as
+authoritative.
+
+> **RNX version == Joblet server version**: RNX ships inside this repo.
+
+## Joblet server ↔ proto
+
+| Joblet server (= RNX)          | joblet-proto |
+|--------------------------------|--------------|
+| **v5.0.2 – v5.6.11** (current) | v2.x         |
+| v4.5.0 – v5.0.1                | v1.x         |
+
+Latest: Joblet/RNX **v5.6.11** ↔ proto **v2.5.9** (the version this server
+build depends on).
+
+## Client tools
+
+Client tools derive their compatibility from the proto major they target:
+
+| Consumer     | Current | joblet-proto |
+|--------------|---------|--------------|
+| Python SDK   | v2.5.2  | v2.x         |
+| MCP Server   | v1.1.4  | v2.x         |
+| joblet-admin | v1.0.6  | v2.x         |
+
+The authoritative cross-project matrix and the per-RPC feature timeline live in
+[joblet-proto/COMPATIBILITY.md](https://github.com/ehsaniara/joblet-proto/blob/main/COMPATIBILITY.md).

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 # Simple Joblet Makefile
-REMOTE_HOST ?= 192.168.1.161
-REMOTE_USER ?= jay
+#
+# Everything targets this machine by default; pass parameters to override:
+#   make deploy                                  # deploy to localhost, native arch
+#   make deploy REMOTE_HOST=10.0.0.5             # deploy to a remote host over ssh
+#   make deploy REMOTE_HOST=10.0.0.5 GOARCH=amd64  # remote host with a different arch
+REMOTE_HOST ?=
+REMOTE_USER ?= $(USER)
+
+# Target architecture (native unless specified)
+GOARCH ?= $(shell go env GOARCH)
 
 # Fix GOPATH if IntelliJ IDEA has set it incorrectly
 export GOPATH := $(HOME)/go
@@ -26,29 +34,29 @@ LDFLAGS := -s -w \
 	-X github.com/ehsaniara/joblet/pkg/version.GitTag=$(GIT_TAG) \
 	-X github.com/ehsaniara/joblet/pkg/version.BuildDate=$(BUILD_DATE)
 
-.PHONY: all clean deploy test proto bpf help joblet rnx persist state version
+.PHONY: all clean deploy fresh-install pre-pr test proto bpf help joblet rnx persist state version
 
 all: joblet rnx persist state
 	@echo "✅ Build complete - all binaries ready"
 
 joblet:
 	@echo "Building joblet daemon..."
-	@GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS) -X github.com/ehsaniara/joblet/pkg/version.Component=joblet" -o bin/joblet ./cmd/joblet
+	@GOOS=linux GOARCH=$(GOARCH) go build -ldflags="$(LDFLAGS) -X github.com/ehsaniara/joblet/pkg/version.Component=joblet" -o bin/joblet ./cmd/joblet
 	@echo "✅ joblet built (version: $(VERSION))"
 
 rnx:
 	@echo "Building rnx CLI..."
-	@GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS) -X github.com/ehsaniara/joblet/pkg/version.Component=rnx" -o bin/rnx ./cmd/rnx
+	@GOOS=linux GOARCH=$(GOARCH) go build -ldflags="$(LDFLAGS) -X github.com/ehsaniara/joblet/pkg/version.Component=rnx" -o bin/rnx ./cmd/rnx
 	@echo "✅ rnx built (version: $(VERSION))"
 
 persist:
 	@echo "Building persist..."
-	@cd persist && GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS) -X github.com/ehsaniara/joblet/pkg/version.Component=persist" -o ../bin/persist ./cmd/persist
+	@cd persist && GOOS=linux GOARCH=$(GOARCH) go build -ldflags="$(LDFLAGS) -X github.com/ehsaniara/joblet/pkg/version.Component=persist" -o ../bin/persist ./cmd/persist
 	@echo "✅ persist built (version: $(VERSION))"
 
 state:
 	@echo "Building state..."
-	@cd state && GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS) -X github.com/ehsaniara/joblet/pkg/version.Component=state" -o ../bin/state ./cmd/state
+	@cd state && GOOS=linux GOARCH=$(GOARCH) go build -ldflags="$(LDFLAGS) -X github.com/ehsaniara/joblet/pkg/version.Component=state" -o ../bin/state ./cmd/state
 	@echo "✅ state built (version: $(VERSION))"
 
 proto:
@@ -72,7 +80,24 @@ clean:
 	rm -f internal/joblet/ebpf/telematics/telematics_*_bpfel.o
 
 deploy: all
-	@echo "Deploying to $(REMOTE_USER)@$(REMOTE_HOST)..."
+ifeq ($(strip $(REMOTE_HOST)),)
+	@test -d /opt/joblet/bin || { echo "❌ /opt/joblet/bin not found - install the joblet package first"; exit 1; }
+	@echo "Deploying to localhost ($(GOARCH))..."
+	@echo "Stopping services..."
+	@sudo systemctl stop joblet.service || true
+	@echo "Installing binaries..."
+	@sudo cp bin/joblet bin/rnx bin/persist bin/state /opt/joblet/bin/ && sudo chmod +x /opt/joblet/bin/*
+	@echo "Starting services..."
+	@sudo systemctl start joblet.service
+	@echo "Waiting for service readiness (persist socket + gRPC)..."
+	@ready=0; for i in $$(seq 1 30); do \
+		if [ -S /opt/joblet/run/persist-ipc.sock ] && ./bin/rnx job list >/dev/null 2>&1; then ready=1; sleep 1; break; fi; \
+		sleep 0.5; \
+	done; \
+	if [ $$ready -eq 1 ]; then echo "✅ Local deployment complete (persist and state run as subprocesses)"; \
+	else echo "⚠️  Service started but not ready after 15s - check: journalctl -u joblet"; exit 1; fi
+else
+	@echo "Deploying to $(REMOTE_USER)@$(REMOTE_HOST) ($(GOARCH))..."
 	@ssh $(REMOTE_USER)@$(REMOTE_HOST) "mkdir -p /tmp/joblet/build"
 	@echo "Copying binaries..."
 	@scp bin/joblet bin/rnx bin/persist bin/state $(REMOTE_USER)@$(REMOTE_HOST):/tmp/joblet/build/
@@ -82,7 +107,28 @@ deploy: all
 	@ssh $(REMOTE_USER)@$(REMOTE_HOST) 'sudo cp /tmp/joblet/build/* /opt/joblet/bin/ && sudo chmod +x /opt/joblet/bin/*'
 	@echo "Starting services..."
 	@ssh $(REMOTE_USER)@$(REMOTE_HOST) 'sudo systemctl start joblet.service'
-	@echo "✅ Deployment complete (persist and state run as subprocesses)"
+	@echo "✅ Remote deployment complete (persist and state run as subprocesses)"
+endif
+
+fresh-install: all
+	@echo "Purging existing joblet installation..."
+	@sudo ./scripts/uninstall.sh --purge
+	@echo "Building package from local working tree..."
+	@./scripts/build-deb.sh $(GOARCH) $(VERSION)
+	@echo "Installing package..."
+	@sudo DEBIAN_FRONTEND=noninteractive dpkg -i "$$(ls -t joblet_*_$(GOARCH).deb | head -1)"
+	@echo "Starting service..."
+	@sudo systemctl start joblet.service
+	@echo "Waiting for service readiness (persist socket + gRPC)..."
+	@ready=0; for i in $$(seq 1 30); do \
+		if [ -S /opt/joblet/run/persist-ipc.sock ] && ./bin/rnx job list >/dev/null 2>&1; then ready=1; sleep 1; break; fi; \
+		sleep 0.5; \
+	done; \
+	if [ $$ready -eq 1 ]; then echo "✅ Fresh install complete - brand new setup from local build"; \
+	else echo "⚠️  Service started but not ready after 15s - check: journalctl -u joblet"; exit 1; fi
+
+pre-pr:
+	@./scripts/pre-pr-check.sh
 
 test:
 	@echo "Running tests..."
@@ -108,7 +154,9 @@ help:
 	@echo "  make version        - Show version information"
 	@echo "  make clean          - Remove build artifacts"
 	@echo "  make test           - Run all tests (all modules)"
-	@echo "  make deploy         - Deploy to remote server"
+	@echo "  make deploy         - Deploy to this host (default) or REMOTE_HOST=ip for remote"
+	@echo "  make fresh-install  - Purge install, rebuild local .deb, install from scratch"
+	@echo "  make pre-pr         - Full pre-PR check: deploy + e2e + packaged install"
 	@echo ""
 	@echo "Version Information:"
 	@echo "  Version:    $(VERSION)"
@@ -122,6 +170,5 @@ help:
 	@echo "Proto Version:"
 	@echo "  $(shell go list -m github.com/ehsaniara/joblet-proto 2>/dev/null | awk '{print $$2}' || echo 'not found')"
 	@echo ""
-	@echo "Deployment:"
-	@echo "  REMOTE_HOST=$(REMOTE_HOST)"
-	@echo "  REMOTE_USER=$(REMOTE_USER)"
+	@echo "Deployment (localhost by default; override parametrically):"
+	@echo "  make deploy REMOTE_HOST=<ip> REMOTE_USER=<user> GOARCH=<arch>"

--- a/README.MD
+++ b/README.MD
@@ -301,6 +301,7 @@ npm run dev
 - **[Security Guide](docs/SECURITY.md)** - Security configuration and best practices
 - **[Monitoring Guide](docs/MONITORING.md)** - eBPF telemetry, metrics, and observability
 - **[Working Examples](examples/)** - Production-ready runtime configurations and job examples
+- **[Compatibility](COMPATIBILITY.md)** - Joblet/RNX ↔ `joblet-proto` ↔ client-tool version matrix
 
 ## Related Projects
 

--- a/cmd/joblet/main.go
+++ b/cmd/joblet/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ehsaniara/joblet/internal/modes"
 	"github.com/ehsaniara/joblet/pkg/config"
@@ -14,10 +15,32 @@ import (
 )
 
 func main() {
-	// Load configuration first
-	cfg, path, err := config.LoadConfig()
-	if err != nil {
-		log.Fatalf("Failed to load configuration: %v", err)
+	// Determine mode before touching any config: the init process runs inside
+	// the job filesystem where no server config exists (and must not - it
+	// embeds private keys). Init gets everything it needs from JOB_* env vars
+	// and built-in defaults, without any config file I/O.
+	var cfg *config.Config
+	var path string
+	if os.Getenv("JOBLET_MODE") == "init" {
+		cfg = config.InitConfig()
+		cfg.Server.Mode = "init"
+		path = config.BuiltInDefaultsPath
+	} else {
+		var err error
+		cfg, path, err = config.LoadConfig()
+		if err != nil {
+			log.Fatalf("Failed to load configuration: %v", err)
+		}
+
+		// Fail fast: a server without a config file is a broken installation.
+		// Running on built-in defaults would silently use wrong addresses, no
+		// certificates, and wrong paths.
+		if cfg.Server.Mode == "server" && strings.HasPrefix(path, config.BuiltInDefaultsPath) {
+			log.Fatalf("No configuration file found - refusing to start server with built-in defaults.\n" +
+				"This indicates a broken installation. Expected config at one of:\n" +
+				"  $JOBLET_CONFIG_PATH, /opt/joblet/config/joblet-config.yml, ./config/joblet-config.yml, ./joblet-config.yml, /etc/joblet/joblet-config.yml\n" +
+				"Reinstall the joblet package or run: JOBLET_SERVER_ADDRESS='<ip>' /usr/local/bin/certs_gen_embedded.sh")
+		}
 	}
 
 	// Initialize logging with configuration

--- a/debian/postinst
+++ b/debian/postinst
@@ -150,6 +150,18 @@ case "$1" in
             # Users can copy to ~/.rnx/ for personal use or use directly
             chmod 644 ${JOBLET_HOME}/config/rnx-config.yml
 
+            # Set up ~/.rnx for the user who ran the install (sudo), so rnx
+            # works out of the box for them
+            if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+                SUDO_USER_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+                if [ -n "$SUDO_USER_HOME" ] && [ -d "$SUDO_USER_HOME" ]; then
+                    mkdir -p "$SUDO_USER_HOME/.rnx"
+                    cp ${JOBLET_HOME}/config/rnx-config.yml "$SUDO_USER_HOME/.rnx/rnx-config.yml"
+                    chown -R "$SUDO_USER:" "$SUDO_USER_HOME/.rnx"
+                    echo "  Client config installed to $SUDO_USER_HOME/.rnx/rnx-config.yml"
+                fi
+            fi
+
         else
             print_error "Failed to generate certificates"
             exit 1
@@ -185,6 +197,13 @@ case "$1" in
         # Enable systemd services
         systemctl daemon-reload
         systemctl enable joblet.service
+
+        # On upgrade ($2 = old version), restart the service that prerm stopped;
+        # on fresh install leave it stopped so the operator starts it explicitly
+        if [ -n "$2" ]; then
+            print_info "Restarting joblet service after upgrade..."
+            systemctl restart joblet.service || print_error "joblet service failed to start - check: journalctl -u joblet"
+        fi
 
         # Clean up temporary files (EC2 info may be used for AWS deployments)
         rm -f /tmp/joblet-ec2-info

--- a/debian/postrm
+++ b/debian/postrm
@@ -17,6 +17,8 @@ case "$1" in
         # Remove symlinks
         rm -f /usr/bin/joblet
         rm -f /usr/bin/rnx
+        rm -f /usr/local/bin/joblet
+        rm -f /usr/local/bin/rnx
 
         # Note: Job logs in ${JOBLET_HOME}/logs are preserved
         # Use 'apt purge joblet' to remove all data including job logs
@@ -34,6 +36,18 @@ case "$1" in
             userdel joblet 2>/dev/null || true
         fi
 
+        # Remove per-user rnx client configs installed by postinst
+        rm -rf /root/.rnx
+        for home in /home/*; do
+            rm -rf "$home/.rnx" 2>/dev/null || true
+        done
+
+        # Clean up journal logs: remove a dedicated joblet namespace if present,
+        # and rotate so shared-journal entries expire with journald retention
+        systemctl stop systemd-journald@joblet.service 2>/dev/null || true
+        rm -rf /var/log/journal/*.joblet /run/log/journal/*.joblet 2>/dev/null || true
+        journalctl --rotate 2>/dev/null || true
+
         # Count log files before removal
         LOG_COUNT=0
         if [ -d "${JOBLET_HOME}/logs" ]; then
@@ -47,10 +61,19 @@ case "$1" in
         # Remove symlinks
         rm -f /usr/bin/joblet
         rm -f /usr/bin/rnx
+        rm -f /usr/local/bin/joblet
+        rm -f /usr/local/bin/rnx
 
         if [ "$LOG_COUNT" -gt 0 ]; then
             echo "Removed $LOG_COUNT job log files"
         fi
+
+        # Forget stored debconf answers so a future install asks again
+        if [ -f /usr/share/debconf/confmodule ]; then
+            . /usr/share/debconf/confmodule
+            db_purge
+        fi
+
         echo "Joblet service purged successfully!"
         ;;
 esac

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,7 +39,7 @@ access control for organizational deployment scenarios.
 - **Communication Protocol**: gRPC over TLS 1.3 with HTTP/2 multiplexing
 - **Message Serialization**: Protocol Buffers (protobuf) for efficient binary encoding
 - **Security Framework**: Mutual TLS authentication with X.509 client certificate validation
-- **Access Control**: Role-based authorization system (Administrative/Viewer permissions)
+- **Access Control**: Role-based authorization system (admin, maintainer, developer, and reader roles)
 - **Real-time Capabilities**: Server-side streaming for live log aggregation and job monitoring
 - **Isolation Architecture**: Linux kernel namespaces with configurable network policies
 - **Logging Infrastructure**: Asynchronous log persistence system supporting 5M+ writes per second
@@ -89,9 +89,15 @@ issued by the same Certificate Authority (CA) that signed the server certificate
 Client Certificate Subject Format:
 CN=<client-name>, OU=<role>, O=<organization>
 
-Supported Roles:
-- OU=admin  → Full access (all operations)
-- OU=viewer → Read-only access (get, list, stream)
+Supported Roles (OU matched case-insensitively):
+- OU=admin      → Full access, including removal of runtimes, networks, and volumes
+- OU=maintainer → Developer access plus runtime builds and network/volume creation;
+                  meant for CI/CD service accounts. No removal of shared infrastructure
+- OU=developer  → Run, stop, and delete jobs; test runtimes; read everything else
+- OU=reader     → Read-only: job status, logs, listings, metrics
+
+"viewer" is still accepted and treated as reader. Certificates whose OU doesn't
+match any role are rejected on every call.
 ```
 
 #### Certificate Files Required
@@ -99,16 +105,30 @@ Supported Roles:
 ```text
 certs/
 ├── ca-cert.pem           # Certificate Authority
-├── client-cert.pem       # Client certificate (admin or viewer)
+├── client-cert.pem       # Client certificate (role carried in OU)
 └── client-key.pem        # Client private key
 ```
 
 ### Role-Based Authorization
 
-| Role       | RunJob | GetJobStatus | StopJob | CancelJob | DeleteJob | DeleteAllJobs | ListJobs | GetJobLogs | GetJobMetrics |
-|------------|--------|--------------|---------|-----------|-----------|---------------|----------|------------|---------------|
-| **admin**  | ✅      | ✅            | ✅       | ✅         | ✅         | ✅             | ✅        | ✅          | ✅             |
-| **viewer** | ❌      | ✅            | ❌       | ❌         | ❌         | ❌             | ✅        | ✅          | ✅             |
+Every operation requires a certificate with a recognized role. Authorization per service and method:
+
+| Service               | Methods                                                                          | admin | maintainer | developer | reader |
+|-----------------------|----------------------------------------------------------------------------------|-------|------------|-----------|--------|
+| **JobService**        | RunJob, StopJob, CancelJob, DeleteJob, DeleteAllJobs                             | ✅     | ✅          | ✅         | ❌      |
+| **JobService**        | GetJobStatus, ListJobs, GetJobLogs, GetJobMetrics, and log/status/metric streams | ✅     | ✅          | ✅         | ✅      |
+| **RuntimeService**    | ListRuntimes, GetRuntimeInfo                                                     | ✅     | ✅          | ✅         | ✅      |
+| **RuntimeService**    | TestRuntime                                                                      | ✅     | ✅          | ✅         | ❌      |
+| **RuntimeService**    | BuildRuntime, ValidateRuntimeYAML                                                | ✅     | ✅          | ❌         | ❌      |
+| **RuntimeService**    | RemoveRuntime                                                                    | ✅     | ❌          | ❌         | ❌      |
+| **NetworkService**    | ListNetworks                                                                     | ✅     | ✅          | ✅         | ✅      |
+| **NetworkService**    | CreateNetwork                                                                    | ✅     | ✅          | ❌         | ❌      |
+| **NetworkService**    | RemoveNetwork                                                                    | ✅     | ❌          | ❌         | ❌      |
+| **VolumeService**     | ListVolumes                                                                      | ✅     | ✅          | ✅         | ✅      |
+| **VolumeService**     | CreateVolume                                                                     | ✅     | ✅          | ❌         | ❌      |
+| **VolumeService**     | RemoveVolume                                                                     | ✅     | ❌          | ❌         | ❌      |
+| **MonitoringService** | GetSystemStatus, StreamSystemMetrics                                             | ✅     | ✅          | ✅         | ✅      |
+| **Persist**           | Historical log and metric queries                                                | ✅     | ✅          | ✅         | ✅      |
 
 ## Service Definition
 
@@ -139,7 +159,7 @@ service JobService {
 Creates and starts a new job with specified command and resource limits. Jobs execute on the Linux server with complete
 process isolation.
 
-**Authorization**: Admin only
+**Authorization**: admin, maintainer, developer
 
 ```protobuf
 rpc RunJob(RunJobRequest) returns (RunJobResponse);
@@ -185,7 +205,7 @@ Network: host (shared with system)
 
 Retrieves detailed information about a specific job, including current status, resource usage, and execution metadata.
 
-**Authorization**: Admin, Viewer
+**Authorization**: All roles (admin, maintainer, developer, reader)
 
 ```protobuf
 rpc GetJobStatus(GetJobStatusReq) returns (GetJobStatusRes);
@@ -221,7 +241,7 @@ ExitCode: 0
 
 Terminates a running job using graceful shutdown (SIGTERM) followed by force termination (SIGKILL) if necessary.
 
-**Authorization**: Admin only
+**Authorization**: admin, maintainer, developer
 
 ```protobuf
 rpc StopJob(StopJobReq) returns (StopJobRes);
@@ -261,7 +281,7 @@ EndTime: 2024-01-15T10:45:00Z
 
 Cancels a scheduled job before it starts executing. This is specifically for jobs in SCHEDULED status.
 
-**Authorization**: Admin only
+**Authorization**: admin, maintainer, developer
 
 ```protobuf
 rpc CancelJob(CancelJobReq) returns (CancelJobRes);
@@ -310,7 +330,7 @@ CanceledAt: 2024-01-15T10:45:00Z
 
 Permanently deletes a job and all its associated data including logs, metrics, and metadata.
 
-**Authorization**: Admin only
+**Authorization**: admin, maintainer, developer
 
 ```protobuf
 rpc DeleteJob(DeleteJobReq) returns (DeleteJobRes);
@@ -358,7 +378,7 @@ ID: f47ac10b-58cc-4372-a567-0e02b2c3d479
 
 Deletes all non-running jobs from the system in a single operation. Running and scheduled jobs are preserved.
 
-**Authorization**: Admin only
+**Authorization**: admin, maintainer, developer
 
 ```protobuf
 rpc DeleteAllJobs(DeleteAllJobsReq) returns (DeleteAllJobsRes);
@@ -399,7 +419,7 @@ Successfully deleted 15 jobs, skipped 3 running/scheduled jobs
 
 Lists all jobs with their current status and metadata. Useful for monitoring overall system activity.
 
-**Authorization**: Admin, Viewer
+**Authorization**: All roles (admin, maintainer, developer, reader)
 
 ```protobuf
 rpc ListJobs(EmptyRequest) returns (Jobs);
@@ -428,7 +448,7 @@ f47ac10b-58cc-4372-a567-0e02b2c3d479 COMPLETED StartTime: 2024-01-15T10:30:00Z C
 Streams job output in real-time, including historical logs and live updates. Supports multiple concurrent clients
 streaming the same job.
 
-**Authorization**: Admin, Viewer
+**Authorization**: All roles (admin, maintainer, developer, reader)
 
 ```protobuf
 rpc GetJobLogs(GetJobLogsReq) returns (stream DataChunk);
@@ -470,7 +490,7 @@ Script completed successfully
 Streams resource usage metrics for a job as time-series data. Shows CPU, memory, I/O, network, process, and GPU metrics
 collected during job execution.
 
-**Authorization**: Admin, Viewer
+**Authorization**: All roles (admin, maintainer, developer, reader)
 
 ```protobuf
 rpc GetJobMetrics(JobMetricsRequest) returns (stream JobMetricsSample);
@@ -684,7 +704,7 @@ message DataChunk {
 | Code                | Description                           | Common Causes                     |
 |---------------------|---------------------------------------|-----------------------------------|
 | `UNAUTHENTICATED`   | Invalid or missing client certificate | Certificate expired, wrong CA     |
-| `PERMISSION_DENIED` | Insufficient role permissions         | Viewer trying admin operation     |
+| `PERMISSION_DENIED` | Insufficient role permissions         | Reader trying to run a job        |
 | `NOT_FOUND`         | Job not found                         | Invalid job UUID                  |
 | `INTERNAL`          | Server-side error                     | Job creation failed, system error |
 | `CANCELED`          | Operation canceled                    | Client disconnected during stream |
@@ -708,8 +728,8 @@ message DataChunk {
 # Missing certificate
 Error: failed to extract client role: no TLS information found
 
-# Wrong role (viewer trying to run job)
-Error: role viewer is not allowed to perform operation run_job
+# Wrong role (reader trying to run job)
+Error: role reader is not allowed to perform operation run_job
 
 # Invalid certificate
 Error: certificate verify failed: certificate has expired
@@ -1213,7 +1233,7 @@ find /opt/joblet/metrics -type d -mtime +90 -exec rm -rf {} \;
 - **ListJobs**: Fully implemented job listing functionality
     - Returns all jobs with complete metadata
     - Includes job status, resource limits, and timestamps
-    - Proper authorization checks for admin/viewer roles
+  - Proper role-based authorization checks
 
 #### Monitoring Enhancements
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -314,7 +314,7 @@ Single systemd service:
 ### Deployment Command
 
 ```bash
-make deploy REMOTE_HOST=192.168.1.161 REMOTE_USER=jay
+make deploy REMOTE_HOST=192.0.2.10 REMOTE_USER=admin
 ```
 
 This builds all binaries, copies to remote server, and restarts services.

--- a/docs/AWS_DEPLOYMENT.md
+++ b/docs/AWS_DEPLOYMENT.md
@@ -268,7 +268,7 @@ When using S3 storage backend, the pre-setup script also configures:
 ### Secrets Manager (TLS Certificates)
 
 - **Shared CA certificate** (`joblet/ca-cert`, `joblet/ca-key`) - Same across all instances
-- **Shared client certificate** (`joblet/client-cert`, `joblet/client-key`) - Same for all clients
+- **Client certificates, one pair per role** (`joblet/client-cert[-<role>]`, `joblet/client-key[-<role>]`; unsuffixed names are the admin pair) - Scope each client's IAM policy to only its role's secrets
 - **Instance-specific server certificate** - Generated fresh on each EC2 instance
 - **Enables horizontal scaling** - Multiple Joblet instances share the same CA/client trust
 - **Created automatically** by the pre-setup script

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -295,7 +295,9 @@ security:
 
   # Authorization
   enable_rbac: true              # Enable role-based access control
-  default_role: "viewer"         # Default role for unknown OUs
+  # Role comes from the client certificate OU: admin, maintainer,
+  # developer, or reader (the old "viewer" still works and maps to
+  # reader). Anything else is rejected.
 
   # Audit logging
   audit:
@@ -771,12 +773,12 @@ nodes:
       -----END CERTIFICATE-----
     # ... rest of credentials
 
-  viewer:
+  reader:
     address: "prod.joblet.company.com:50051"
-    nodeId: "a1b2c3d4-5678-9abc-def0-123456789012"  # Same as production (viewer access)
+    nodeId: "a1b2c3d4-5678-9abc-def0-123456789012"  # Same as production (read-only access)
     cert: |
       -----BEGIN CERTIFICATE-----
-      # Viewer certificate (OU=viewer)
+      # Reader certificate (OU=reader)
       -----END CERTIFICATE-----
     # ... rest of credentials
 
@@ -837,26 +839,58 @@ nodes:
 
 ### Authentication Roles
 
-Joblet uses certificate Organization Units (OU) for role-based access:
+A client's role comes from the OU field of its certificate (case doesn't matter). Certificates without one of these
+OUs are rejected on every request.
+
+| Role         | Access                                                                                                                                    |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `admin`      | Everything, including removing runtimes, networks, and volumes                                                                            |
+| `maintainer` | Developer access plus building runtimes, validating runtime YAML, and creating networks and volumes; intended for CI/CD. No removals     |
+| `developer`  | Run, stop, and delete jobs; test runtimes; read everything. No infrastructure changes                                                     |
+| `reader`     | Read-only: jobs, logs, telemetry, and resource listings, for dashboards and reporting                                                    |
+
+Certificates issued with the old `viewer` OU keep working; they are treated as `reader`.
 
 ```yaml
-# Admin role certificate (full access)
-# Certificate subject: /CN=admin-client/OU=admin
-
-# Viewer role certificate (read-only)
-# Certificate subject: /CN=viewer-client/OU=viewer
+# Certificate subjects per role
+# /CN=admin-client/OU=admin
+# /CN=maintainer-client/OU=maintainer
+# /CN=developer-client/OU=developer
+# /CN=reader-client/OU=reader
 ```
 
-Generate role-specific certificates:
+Both certificate scripts (`scripts/certs_gen_embedded.sh` and the AWS variant
+`scripts/certs_gen_with_secretsmanager.sh`) generate one client certificate per role and write two kinds of client
+config:
+
+- `rnx-config.yml`: the operator's copy, with one node per role plus `default` (admin certificate). It contains the
+  admin key, so it stays on the server. On the server, select a role with `rnx --node <role> ...`.
+- `rnx-config-<role>.yml`: one self-contained file per role, with that role's node as `default`. Hand each party the
+  file for its role and nothing else; a developer holding `rnx-config-developer.yml` never sees the admin key.
+
+The AWS variant additionally stores each role's certificate pair in Secrets Manager
+(`joblet/client-cert-<role>` and `joblet/client-key-<role>`; the unsuffixed `joblet/client-cert` and
+`joblet/client-key` are the admin pair, kept under their original names). Scope each client's IAM policy to only its
+role's secrets so clients can fetch their own credentials without any file distribution.
+
+Generate role-specific certificates manually:
 
 ```bash
 # Admin certificate
 openssl req -new -key client-key.pem -out admin.csr \
   -subj "/CN=admin-client/OU=admin"
 
-# Viewer certificate  
-openssl req -new -key client-key.pem -out viewer.csr \
-  -subj "/CN=viewer-client/OU=viewer"
+# Maintainer certificate
+openssl req -new -key client-key.pem -out maintainer.csr \
+  -subj "/CN=maintainer-client/OU=maintainer"
+
+# Developer certificate
+openssl req -new -key client-key.pem -out developer.csr \
+  -subj "/CN=developer-client/OU=developer"
+
+# Reader certificate
+openssl req -new -key client-key.pem -out reader.csr \
+  -subj "/CN=reader-client/OU=reader"
 ```
 
 ## Environment Variables

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -603,7 +603,7 @@ The certificate generation includes proper SAN (Subject Alternative Name) config
 DNS.1 = joblet
 DNS.2 = localhost
 DNS.3 = joblet-server
-IP.1 = 192.168.1.161
+IP.1 = 192.0.2.10
 IP.2 = 127.0.0.1
 IP.3 = 0.0.0.0
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -72,15 +72,15 @@ Joblet supports multiple deployment architectures depending on your infrastructu
 
 ```mermaid
 flowchart TB
-    subgraph single["Single Node — vertical scaling"]
+    subgraph single["Single Node (vertical scaling)"]
         SN["Joblet + Persist + State"] --> SL["Local Filesystem"]
     end
-    subgraph multi["Multi-Node Cluster — horizontal scaling"]
+    subgraph multi["Multi-Node Cluster (horizontal scaling)"]
         MN1["Node 1: Joblet"] --> ML1["Local FS + backup"]
         MN2["Node 2: Joblet"] --> ML2["Local FS + backup"]
         MNn["Node N: Joblet"] --> MLn["Local FS + backup"]
     end
-    subgraph aws["AWS EC2 — auto-scaling"]
+    subgraph aws["AWS EC2 (auto-scaling)"]
         ASG["Auto Scaling Group<br/>Joblet nodes"] --> CW["CloudWatch Logs"]
         ASG --> DDB["DynamoDB (state)"]
     end
@@ -578,14 +578,21 @@ sudo systemctl stop joblet.service
 The Joblet includes comprehensive certificate management:
 
 ```bash
-# Generate all certificates (CA, server, admin, viewer)
+# Generate all certificates: CA, server, and one client certificate per role
+# (admin, maintainer, developer, reader)
 sudo /usr/local/bin/certs_gen_embedded.sh
 
 # Certificate structure created:
 # /opt/joblet/config/
 # ├── joblet-config.yml           # Server config with embedded certificates
-# └── rnx-config.yml             # Client config with embedded certificates
+# └── rnx-config.yml             # Client config with one node per role plus
+#                                 # "default" (admin certificate)
 ```
+
+The certificate OU decides what each client may do: `admin` can do everything, `maintainer` adds runtime builds and
+network/volume creation on top of `developer`, which can only run jobs, and `reader` is limited to reads.
+Certificates issued with the old `viewer` OU still work and behave like `reader`. The full permission matrix is in
+[SECURITY.md](SECURITY.md).
 
 ### Certificate Configuration
 
@@ -607,11 +614,19 @@ openssl x509 -in /opt/joblet/certs/server-cert.pem -noout -text | grep -A 10 "Su
 ### Certificate Distribution
 
 ```bash
-# For admin clients
-scp server:/opt/joblet/config/rnx-config.yml ~/.rnx/
+# Give each party the config file for its role and nothing else.
+# The combined rnx-config.yml contains the admin key and stays on the server.
+scp server:/opt/joblet/config/rnx-config-developer.yml dev-box:~/.rnx/rnx-config.yml
+scp server:/opt/joblet/config/rnx-config-maintainer.yml ci-runner:~/.rnx/rnx-config.yml
+scp server:/opt/joblet/config/rnx-config-reader.yml dashboard:~/.rnx/rnx-config.yml
 
-# For viewer clients (if separate viewer config exists)
-scp server:/opt/joblet/config/rnx-config-viewer.yml ~/.rnx/rnx-config.yml
+# Each per-role file is self-contained with its role as "default",
+# so recipients run rnx with no --node flag
+rnx job list
+
+# On AWS, skip the file copying: each role's certificate pair is in Secrets
+# Manager (joblet/client-cert-<role>), so scope each client's IAM policy to
+# its role's secrets and let clients fetch their own credentials
 
 # Set proper permissions
 chmod 600 ~/.rnx/rnx-config.yml

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -18,7 +18,7 @@ v2.
 - **Real-time Streaming**: Live output streaming with pub/sub architecture
 - **Async Log Persistence**: Rate-decoupled log system with 5M+ writes/second for HPC workloads
 - **Cross-Platform CLI**: Multi-platform client support for remote job management
-- **Role-Based Security**: Certificate-based authentication with admin/viewer roles
+- **Role-Based Security**: Certificate-based authentication with admin, maintainer, developer, and reader roles
 - **Embedded Certificates**: Configuration files contain all necessary certificates
 
 ### 1.2 Design Goals
@@ -46,7 +46,7 @@ flowchart LR
         RE["Resource enforcement (cgroups v2)"]
         ST["State management"]
     end
-    subgraph job["Job Process — init mode (same binary)"]
+    subgraph job["Job Process: init mode (same binary)"]
         NS["Namespaces: PID / mount / IPC / UTS / cgroup"]
         EXE["Command execution"]
         OUT["stdout / stderr capture"]
@@ -122,8 +122,16 @@ return modes.RunServer(cfg)
 
 #### Certificate-Based Roles
 
-- **Admin Certificate** (`OU=admin`): Full job control (run, stop, view)
-- **Viewer Certificate** (`OU=viewer`): Read-only access (status, logs, list)
+The client role is carried in the certificate's OU field (matched case-insensitively):
+
+- **Admin Certificate** (`OU=admin`): Full control of the node, including removing runtimes, networks, and volumes
+- **Maintainer Certificate** (`OU=maintainer`): Provisions runtimes, networks, and volumes and runs jobs; the role
+  to issue to CI/CD pipelines. Removal of shared infrastructure stays with admin
+- **Developer Certificate** (`OU=developer`): Runs jobs against the runtimes, networks, and volumes that already
+  exist on the node
+- **Reader Certificate** (`OU=reader`): Observation only: job status, logs, and metrics. Certificates with the
+  older `OU=viewer` behave the same way
+- **No Recognized Role**: Any other OU is rejected on every request
 - **Embedded Certificates**: All certificates stored in configuration files
 
 ### 3.2 Process Isolation
@@ -172,10 +180,10 @@ resources:
 ```mermaid
 flowchart TD
     A["Client: rnx job run"] -->|"gRPC request"| B["Server validates request & authorizes"]
-    B --> C["Create job — INITIALIZING"]
+    B --> C["Create job (INITIALIZING)"]
     C --> D["Set up isolation:<br/>namespaces + cgroup + chroot"]
     D --> E["fork + exec job binary (init mode)"]
-    E --> F["Job process — RUNNING"]
+    E --> F["Job process (RUNNING)"]
     F --> G{"Outcome"}
     G -->|"exit code 0"| H["COMPLETED"]
     G -->|"exit code != 0"| I["FAILED"]
@@ -462,11 +470,14 @@ nodes:
     ca: |
       -----BEGIN CERTIFICATE-----
       # CA certificate
-  viewer:
+  reader:
     address: "192.168.1.100:50051"
     cert: |
       -----BEGIN CERTIFICATE-----
-      # Viewer client certificate (OU=viewer)
+      # Reader client certificate (OU=reader)
+  # certs_gen_embedded.sh writes one node per role (admin, maintainer,
+  # developer, reader) plus "default", which uses the admin certificate.
+  # Select a role with: rnx --node <role> ...
 ```
 
 ### 7.2 Configuration Benefits

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -180,7 +180,7 @@ use (
 
 ### One-time setup: compile the BPF objects
 
-The joblet daemon embeds compiled BPF programs (`internal/joblet/ebpf/telematics/telematics_*_bpfel.o`). These are not tracked in git — bytes depend on local `clang`/`llvm`/`libbpf-dev` versions and are rebuilt from `bpf/telematics.c`. Run once after clone, and whenever you edit a `.c` file:
+The joblet daemon embeds compiled BPF programs (`internal/joblet/ebpf/telematics/telematics_*_bpfel.o`). These are not tracked in git: bytes depend on local `clang`/`llvm`/`libbpf-dev` versions and are rebuilt from `bpf/telematics.c`. Run once after clone, and whenever you edit a `.c` file:
 
 ```bash
 sudo apt-get install -y clang llvm libbpf-dev   # Ubuntu/Debian
@@ -189,7 +189,7 @@ make bpf
 
 `make bpf` runs `go generate ./internal/joblet/ebpf/telematics`, which produces both the amd64 and arm64 `.o` files in a single invocation. Without it, building `joblet` will fail with `pattern telematics_*.o: no matching files found`.
 
-> CLI-only contributors (only touching `rnx`) can skip this — `rnx` uses a stub on non-Linux targets and doesn't import the BPF package on Linux either.
+> CLI-only contributors (only touching `rnx`) can skip this; `rnx` uses a stub on non-Linux targets and doesn't import the BPF package on Linux either.
 
 ### Build All Binaries
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -352,7 +352,7 @@ cd tests/e2e
 ./tests/01_isolation_test.sh
 
 # Run with custom host
-JOBLET_TEST_HOST=192.168.1.161 JOBLET_TEST_USER=jay ./run_tests.sh
+JOBLET_TEST_HOST=192.0.2.10 JOBLET_TEST_USER=admin ./run_tests.sh
 ```
 
 **Available E2E Tests:**

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -832,7 +832,8 @@ openssl x509 -req -in server.csr -CA ca-cert.pem -CAkey ca-key.pem \
   -extensions v3_req -extfile <(echo "[v3_req]
 subjectAltName = DNS:localhost,DNS:joblet,IP:127.0.0.1,IP:${JOBLET_SERVER_ADDRESS}")
 
-# Create client certificate
+# Create client certificate. The OU carries the role; repeat with
+# OU=maintainer, OU=developer, or OU=reader for the other roles
 openssl genrsa -out client-key.pem 4096
 openssl req -new -key client-key.pem -out client.csr \
   -subj "/CN=admin-client/OU=admin"

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -171,7 +171,7 @@ Host Information:
   Architecture: amd64
   Uptime:       33d 4h 58m
   Node ID:      8eb41e22-2940-4f83-9066-7d739d057ad2
-  Server IPs:   192.168.1.161, 172.20.0.1
+  Server IPs:   192.0.2.10, 172.20.0.1
   MAC Addresses: 5e:9f:b0:c0:61:22, 1e:45:87:fe:bc:53
 
 Joblet Server:
@@ -184,7 +184,7 @@ Joblet Server:
 
 Network Interfaces:
   ens18:
-    IP:   192.168.1.161
+    IP:   192.0.2.10
     MAC:  5e:9f:b0:c0:61:22
     RX:   16.1 GB (10264780 packets, 0 errors)
     TX:   986.9 MB (3558641 packets, 0 errors)

--- a/docs/NETWORK_MANAGEMENT.md
+++ b/docs/NETWORK_MANAGEMENT.md
@@ -174,23 +174,23 @@ Tests verify:
 
 ```mermaid
 flowchart LR
-    subgraph bridge["bridge (default) — 172.20.0.0/16"]
+    subgraph bridge["bridge (default): 172.20.0.0/16"]
         direction TB
         BJ1["Job"] --- BBR["Bridge + NAT"]
         BJ2["Job"] --- BBR
         BBR --> BNET["Internet"]
     end
-    subgraph custom["custom — user CIDR (e.g. 10.10.0.0/24)"]
+    subgraph custom["custom: user CIDR (e.g. 10.10.0.0/24)"]
         direction TB
         CJ1["Job"] --- CBR["Custom bridge + NAT"]
         CJ2["Job"] --- CBR
         CBR --> CNET["Internet"]
     end
-    subgraph isolated["isolated — point-to-point"]
+    subgraph isolated["isolated: point-to-point"]
         direction TB
         IJ["Job"] -->|"veth + NAT"| INET["Internet"]
     end
-    subgraph none["none — loopback only"]
+    subgraph none["none: loopback only"]
         direction TB
         NJ["Job (lo only, no external access)"]
     end

--- a/docs/PROCESS_ISOLATION.md
+++ b/docs/PROCESS_ISOLATION.md
@@ -28,9 +28,9 @@ flowchart TD
         H3["other host processes"]
     end
     subgraph job["Job PID Namespace (isolated)"]
-        J1["job command — PID 1 (init)"]
-        J2["child process — PID 2"]
-        J3["child process — PID 3+"]
+        J1["job command: PID 1 (init)"]
+        J2["child process: PID 2"]
+        J3["child process: PID 3+"]
         J1 --> J2
         J1 --> J3
     end

--- a/docs/RNX_CLI_REFERENCE.md
+++ b/docs/RNX_CLI_REFERENCE.md
@@ -7,6 +7,7 @@ operations.
 ## Reference Documentation Structure
 
 - [Global Options](#global-options)
+- [Client Roles](#client-roles)
 - [Job Commands](#job-commands)
     - [run](#rnx-job-run)
     - [list](#rnx-job-list)
@@ -61,6 +62,50 @@ RNX resolves configuration files using the following precedence hierarchy:
 3. `~/.rnx/rnx-config.yml`
 4. `/etc/joblet/rnx-config.yml`
 5. `/opt/joblet/config/rnx-config.yml`
+
+## Client Roles
+
+Every RNX command is authorized on the server against the role in your client certificate's OU field. There are four
+roles:
+
+| Role           | Access                                                                                                          |
+|----------------|------------------------------------------------------------------------------------------------------------------|
+| **admin**      | Everything, including `remove` of runtimes, networks, and volumes                                               |
+| **maintainer** | Developer access plus `runtime build`/`validate` and network/volume `create`. The role for CI/CD pipelines      |
+| **developer**  | Full job lifecycle (`run`, `stop`, `delete`) and `runtime test`, plus every read command                        |
+| **reader**     | Read commands only: job status, logs, listings, and monitoring                                                  |
+
+Certificates with the older `viewer` OU behave like reader. Any other OU value gets `PermissionDenied` on every
+command.
+
+### Required Role per Command
+
+| Command                                                                                      | admin | maintainer | developer | reader |
+|----------------------------------------------------------------------------------------------|-------|------------|-----------|--------|
+| `rnx job run` / `rnx job stop` / `rnx job cancel` / `rnx job delete` / `rnx job delete-all`  | ✅     | ✅          | ✅         | ❌      |
+| `rnx job list` / `rnx job status` / `rnx job log` / `rnx job metrics` / `rnx job telematics` | ✅     | ✅          | ✅         | ✅      |
+| `rnx runtime list` / `rnx runtime info`                                                      | ✅     | ✅          | ✅         | ✅      |
+| `rnx runtime test`                                                                           | ✅     | ✅          | ✅         | ❌      |
+| `rnx runtime build` / `rnx runtime validate`                                                 | ✅     | ✅          | ❌         | ❌      |
+| `rnx runtime remove`                                                                         | ✅     | ❌          | ❌         | ❌      |
+| `rnx network list`                                                                           | ✅     | ✅          | ✅         | ✅      |
+| `rnx network create`                                                                         | ✅     | ✅          | ❌         | ❌      |
+| `rnx network remove`                                                                         | ✅     | ❌          | ❌         | ❌      |
+| `rnx volume list`                                                                            | ✅     | ✅          | ✅         | ✅      |
+| `rnx volume create`                                                                          | ✅     | ✅          | ❌         | ❌      |
+| `rnx volume remove`                                                                          | ✅     | ❌          | ❌         | ❌      |
+| `rnx monitor`                                                                                | ✅     | ✅          | ✅         | ✅      |
+
+The certificate generation script (`certs_gen_embedded.sh`) creates one client certificate per role. As a client you
+normally receive a single `rnx-config-<role>.yml` from your operator; save it as `~/.rnx/rnx-config.yml` and run
+`rnx` with no extra flags, since your role is its `default` node. Operators working on the server itself have the
+combined `rnx-config.yml` with every role and pick one per invocation:
+
+```bash
+rnx --node reader job list
+rnx --node maintainer runtime build ./examples/python-3.11-ml/runtime.yaml
+rnx --node admin volume remove old-data
+```
 
 ## Job Management Commands
 
@@ -1439,11 +1484,11 @@ nodes:
       ...
     # ... rest of credentials
 
-  viewer:
+  reader:
     address: "prod-server:50051"
     cert: |
       -----BEGIN CERTIFICATE-----
-      # Viewer certificate with OU=viewer
+      # Reader certificate with OU=reader
       ...
     # ... rest of credentials
 ```
@@ -1458,8 +1503,8 @@ rnx --node=default run production-task.sh
 rnx --node=staging run test-suite.sh
 
 # Read-only access
-rnx --node=viewer list
-rnx --node=viewer monitor status
+rnx --node=reader job list
+rnx --node=reader monitor status
 ```
 
 ## Best Practices

--- a/docs/SCALING_ON_AWS.md
+++ b/docs/SCALING_ON_AWS.md
@@ -104,10 +104,12 @@ aws secretsmanager list-secrets \
   --output table
 
 # Expected output:
-# joblet/ca-cert       - Shared CA certificate
-# joblet/ca-key        - Shared CA private key
-# joblet/client-cert   - Shared client certificate
-# joblet/client-key    - Shared client private key
+# joblet/ca-cert                - Shared CA certificate
+# joblet/ca-key                 - Shared CA private key
+# joblet/client-cert            - admin client certificate (unsuffixed = admin)
+# joblet/client-key             - admin client private key
+# joblet/client-cert-<role>     - maintainer/developer/reader client certificates
+# joblet/client-key-<role>      - maintainer/developer/reader client private keys
 ```
 
 ### 5. Download Client Config
@@ -129,7 +131,7 @@ scp ec2-user@$INSTANCE_IP:/opt/joblet/config/rnx-config.yml ~/.rnx/
 ```mermaid
 flowchart TD
     subgraph SM["AWS Secrets Manager"]
-        S["joblet/ca-cert (Shared)<br/>joblet/ca-key (Shared)<br/>joblet/client-cert (Shared)<br/>joblet/client-key (Shared)"]
+        S["joblet/ca-cert, joblet/ca-key (Shared)<br/>joblet/client-cert, joblet/client-key (admin)<br/>joblet/client-cert-&lt;role&gt;, joblet/client-key-&lt;role&gt;<br/>(maintainer, developer, reader)"]
     end
     SM --> E1["EC2 #1 (Cert1)"]
     SM --> E2["EC2 #2 (Cert2)"]
@@ -235,7 +237,7 @@ aws secretsmanager get-secret-value \
   --query SecretString --output text | \
   openssl x509 -noout -dates
 
-# Check client certificate expiration
+# Check client certificate expiration (repeat for client-cert-<role>)
 aws secretsmanager get-secret-value \
   --secret-id joblet/client-cert \
   --query SecretString --output text | \

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -332,7 +332,7 @@ Planned features for future releases:
 1. **Cron-style recurring schedules**
 2. **Cross-node job reassignment** on failure
 
-> Job dependencies and multi-job orchestration are intentionally out of scope for the executor — they are handled by a
+> Job dependencies and multi-job orchestration are intentionally out of scope for the executor; they are handled by a
 > separate workflow-orchestration project that builds on joblet's Job API (see
 > [ADR-013](adr/013-extract-workflow-to-separate-project.md)).
 

--- a/docs/SECRETS_MANAGER_INTEGRATION.md
+++ b/docs/SECRETS_MANAGER_INTEGRATION.md
@@ -28,7 +28,7 @@ instances while maintaining a shared Certificate Authority (CA) and client certi
 ```mermaid
 flowchart TD
     subgraph SM["AWS Secrets Manager"]
-        N1["joblet/ca-cert (Shared - Generated Once)<br/>joblet/ca-key (Shared - Generated Once)<br/>joblet/client-cert (Shared - Generated Once)<br/>joblet/client-key (Shared - Generated Once)"]
+        N1["joblet/ca-cert, joblet/ca-key (Shared - Generated Once)<br/>joblet/client-cert, joblet/client-key (admin pair)<br/>joblet/client-cert-maintainer, joblet/client-key-maintainer<br/>joblet/client-cert-developer, joblet/client-key-developer<br/>joblet/client-cert-reader, joblet/client-key-reader"]
     end
     N1 --> N2["EC2 Instance #1<br/>Server Cert A (Local)"]
     N1 --> N3["EC2 Instance #2<br/>Server Cert B (Local)"]
@@ -190,10 +190,16 @@ Expected output:
 ----------------------------------------
 |            ListSecrets                |
 +----------------------+----------------+
-|  joblet/ca-cert      | Joblet Root CA Certificate - shared across all instances  |
-|  joblet/ca-key       | Joblet Root CA Private Key - shared across all instances  |
-|  joblet/client-cert  | Joblet Admin Client Certificate - shared across all clients |
-|  joblet/client-key   | Joblet Admin Client Private Key - shared across all clients |
+|  joblet/ca-cert                 | Joblet Root CA Certificate - shared across all instances |
+|  joblet/ca-key                  | Joblet Root CA Private Key - shared across all instances |
+|  joblet/client-cert             | admin client certificate (unsuffixed names predate the four-role model) |
+|  joblet/client-key              | admin client private key |
+|  joblet/client-cert-maintainer  | maintainer client certificate |
+|  joblet/client-key-maintainer   | maintainer client private key |
+|  joblet/client-cert-developer   | developer client certificate |
+|  joblet/client-key-developer    | developer client private key |
+|  joblet/client-cert-reader      | reader client certificate |
+|  joblet/client-key-reader       | reader client private key |
 +----------------------+----------------+
 ```
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -22,7 +22,7 @@ Joblet implements multi-layered security:
 ```mermaid
 flowchart TD
     N1["Transport Layer<br/>mTLS + Certificate Auth"]
-    N2["Authorization Layer<br/>RBAC (admin/viewer)"]
+    N2["Authorization Layer<br/>RBAC (admin/maintainer/developer/reader)"]
     N3["Process Isolation<br/>Namespaces + cgroups + chroot"]
     N4["Network Isolation<br/>Custom networks + traffic"]
     N5["Filesystem Isolation<br/>Per-job workspaces + volumes"]
@@ -32,7 +32,7 @@ flowchart TD
 ### Key Security Features
 
 - **mTLS**: Mutual TLS with certificate-based authentication
-- **RBAC**: Role-based access control (admin/viewer)
+- **RBAC**: Role-based access control (admin/maintainer/developer/reader)
 - **Service-Based Isolation**: Automatic job routing based on API service
 - **Dual Chroot System**: Production isolation (minimal) vs builder isolation (controlled)
 - **Runtime Cleanup**: Self-contained runtime isolation preventing host filesystem exposure
@@ -58,7 +58,13 @@ This creates:
 
 - **CA Certificate**: Root certificate authority
 - **Server Certificate**: For Joblet daemon
-- **Client Certificates**: For RNX clients
+- **Client Certificates**: One per role (admin, maintainer, developer, reader)
+
+The script writes the operator's `rnx-config.yml` (all roles, admin key included, keep it on the server) and one
+`rnx-config-<role>.yml` per role for distribution. Give each party only its role's file. The AWS variant
+(`certs_gen_with_secretsmanager.sh`) produces the same files and also stores each role's certificate pair in Secrets
+Manager as `joblet/client-cert-<role>` and `joblet/client-key-<role>`; scope each client's IAM policy to its role's
+secrets. The unsuffixed `joblet/client-cert` and `joblet/client-key` names hold the admin pair.
 
 ### Certificate Structure
 
@@ -69,11 +75,13 @@ flowchart TD
     N2 --> N4["Used by Joblet daemon"]
     N2 --> N5["Validates server identity"]
     N3 --> N6["Admin Certificate (OU=admin)"]
-    N3 --> N7["Viewer Certificate (OU=viewer)"]
-    N6 --> N8["Full access to all operations"]
-    N6 --> N9["Can run, stop, manage jobs"]
-    N7 --> N10["Read-only access"]
-    N7 --> N11["Can list, view status, logs"]
+    N3 --> N7["Maintainer Certificate (OU=maintainer)"]
+    N3 --> N8["Developer Certificate (OU=developer)"]
+    N3 --> N9["Reader Certificate (OU=reader)"]
+    N6 --> N10["Every operation, including removals"]
+    N7 --> N11["Provision infrastructure + run jobs"]
+    N8 --> N12["Run jobs on existing infrastructure"]
+    N9 --> N13["Read-only access"]
 ```
 
 ### Manual Certificate Generation
@@ -93,19 +101,14 @@ openssl x509 -req -in server.csr -CA ca-cert.pem -CAkey ca-key.pem \
   -extensions v3_req -extfile <(echo "[v3_req]
 subjectAltName = DNS:localhost,DNS:joblet,IP:127.0.0.1,IP:${SERVER_IP}")
 
-# 3. Admin client certificate
-openssl genrsa -out admin-key.pem 4096
-openssl req -new -key admin-key.pem -out admin.csr \
-  -subj "/CN=admin-client/OU=admin"
-openssl x509 -req -in admin.csr -CA ca-cert.pem -CAkey ca-key.pem \
-  -out admin-cert.pem -days 365 -CAcreateserial
-
-# 4. Viewer client certificate
-openssl genrsa -out viewer-key.pem 4096
-openssl req -new -key viewer-key.pem -out viewer.csr \
-  -subj "/CN=viewer-client/OU=viewer"
-openssl x509 -req -in viewer.csr -CA ca-cert.pem -CAkey ca-key.pem \
-  -out viewer-cert.pem -days 365 -CAcreateserial
+# 3. Client certificates (one per role; the OU field carries the role)
+for role in admin maintainer developer reader; do
+  openssl genrsa -out ${role}-key.pem 4096
+  openssl req -new -key ${role}-key.pem -out ${role}.csr \
+    -subj "/CN=${role}-client/OU=${role}"
+  openssl x509 -req -in ${role}.csr -CA ca-cert.pem -CAkey ca-key.pem \
+    -out ${role}-cert.pem -days 365 -CAcreateserial
+done
 ```
 
 ### Certificate Rotation
@@ -157,42 +160,104 @@ security:
 
 ### Role-Based Access Control
 
-Joblet uses certificate Organization Unit (OU) for roles:
+Joblet reads the client's role from the certificate Organizational Unit (OU) field (case-insensitive):
 
-| Role   | OU Value | Permissions                                              |
-|--------|----------|----------------------------------------------------------|
-| Admin  | `admin`  | Full access: run, stop, list, logs, volumes, networks    |
-| Viewer | `viewer` | Read-only: list, status, logs (but cannot run/stop jobs) |
+| Role       | OU Value     | Permissions                                                                                                                                    |
+|------------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| Admin      | `admin`      | Every operation, including removing runtimes, networks, and volumes                                                                            |
+| Maintainer | `maintainer` | Provisions infrastructure (builds runtimes, validates runtime YAML, creates networks and volumes) and everything a developer can do         |
+| Developer  | `developer`  | Runs, stops, and deletes jobs, tests runtimes, and reads everything. Cannot change infrastructure                                              |
+| Reader     | `reader`     | Reads only: jobs, logs, status, resource listings, and metrics. Meant for dashboards and reporting                                             |
+
+Issue `maintainer` certificates to CI/CD service accounts: they can provision what their pipelines need but can never
+remove shared infrastructure. Certificates carrying the older `viewer` OU keep working and behave as `reader`. Any
+other OU is denied everything, and a certificate carrying more than one role OU gets the least privileged of them.
+
+### Permission Matrix
+
+| Service           | Operation                                  | Admin | Maintainer | Developer | Reader |
+|-------------------|--------------------------------------------|:-----:|:----------:|:---------:|:------:|
+| JobService        | RunJob                                     |   ✅   |     ✅      |     ✅     |   ❌    |
+| JobService        | StopJob                                    |   ✅   |     ✅      |     ✅     |   ❌    |
+| JobService        | DeleteJob, DeleteAllJobs                   |   ✅   |     ✅      |     ✅     |   ❌    |
+| JobService        | GetJobStatus, ListJobs, log/status streams |   ✅   |     ✅      |     ✅     |   ✅    |
+| RuntimeService    | ListRuntimes, GetRuntimeInfo               |   ✅   |     ✅      |     ✅     |   ✅    |
+| RuntimeService    | TestRuntime                                |   ✅   |     ✅      |     ✅     |   ❌    |
+| RuntimeService    | BuildRuntime, ValidateRuntimeYAML          |   ✅   |     ✅      |     ❌     |   ❌    |
+| RuntimeService    | RemoveRuntime                              |   ✅   |     ❌      |     ❌     |   ❌    |
+| NetworkService    | ListNetworks                               |   ✅   |     ✅      |     ✅     |   ✅    |
+| NetworkService    | CreateNetwork                              |   ✅   |     ✅      |     ❌     |   ❌    |
+| NetworkService    | RemoveNetwork                              |   ✅   |     ❌      |     ❌     |   ❌    |
+| VolumeService     | ListVolumes                                |   ✅   |     ✅      |     ✅     |   ✅    |
+| VolumeService     | CreateVolume                               |   ✅   |     ✅      |     ❌     |   ❌    |
+| VolumeService     | RemoveVolume                               |   ✅   |     ❌      |     ❌     |   ❌    |
+| MonitoringService | GetSystemStatus, StreamSystemMetrics       |   ✅   |     ✅      |     ✅     |   ✅    |
+| Persist           | Query historical logs/metrics              |   ✅   |     ✅      |     ✅     |   ✅    |
+
+Monitoring endpoints go through the same authorization as everything else: a valid certificate alone is not enough;
+it must carry a recognized role.
 
 ### Admin Role (OU=admin)
 
 ```bash
-# Full access operations
-rnx job run echo "Admin can run jobs"
-rnx job stop <job-id>
-rnx volume create admin-vol --size=1GB
-rnx network create admin-net --cidr=10.1.0.0/24
+# Every operation, including removal of shared infrastructure
+rnx runtime remove openjdk-21
+rnx network remove old-net
+rnx volume remove old-vol
 
-# All monitoring operations
-rnx monitor
-rnx job list
-rnx job status <job-id>
-rnx job log <job-id>
+# Plus everything maintainer, developer, and reader can do
 ```
 
-### Viewer Role (OU=viewer)
+### Maintainer Role (OU=maintainer)
+
+```bash
+# Infrastructure provisioning (allowed)
+rnx runtime build ./examples/java-21/runtime.yaml
+rnx runtime validate ./examples/java-21/runtime.yaml
+rnx network create ci-net --cidr=10.1.0.0/24
+rnx volume create ci-vol --size=1GB
+
+# Plus everything developer can do
+
+# Removal of shared infrastructure (denied)
+rnx runtime remove openjdk-21    # ERROR: Permission denied
+rnx network remove ci-net        # ERROR: Permission denied
+rnx volume remove ci-vol         # ERROR: Permission denied
+```
+
+### Developer Role (OU=developer)
+
+```bash
+# Job execution on existing infrastructure (allowed)
+rnx job run echo "Developers can run jobs"
+rnx job stop <job-id>
+rnx job delete <job-id>
+rnx runtime test openjdk-21
+
+# Plus all read access
+
+# Infrastructure changes (denied)
+rnx runtime build ./runtime.yaml # ERROR: Permission denied
+rnx network create dev-net       # ERROR: Permission denied
+rnx volume create dev-vol        # ERROR: Permission denied
+```
+
+### Reader Role (OU=reader)
 
 ```bash
 # Read-only operations (allowed)
 rnx job list
 rnx job status <job-id>
 rnx job log <job-id>
+rnx runtime list
+rnx network list
+rnx volume list
 rnx monitor status
 
-# Write operations (denied)
+# Create, execute, and delete operations (denied)
 rnx job run echo "test"          # ERROR: Permission denied
 rnx job stop <job-id>            # ERROR: Permission denied
-rnx volume create test       # ERROR: Permission denied
+rnx volume create test           # ERROR: Permission denied
 ```
 
 ### Multi-User Setup
@@ -203,47 +268,23 @@ rnx volume create test       # ERROR: Permission denied
 openssl req -new -key devops-key.pem -out devops.csr \
   -subj "/CN=devops-team/OU=admin"
 
-# Developers (viewer access)
-openssl req -new -key dev-key.pem -out dev.csr \
-  -subj "/CN=developer/OU=viewer"
+# CI/CD service account (maintainer access)
+openssl req -new -key cicd-key.pem -out cicd.csr \
+  -subj "/CN=cicd-pipeline/OU=maintainer"
 
-# QA team (viewer access)
-openssl req -new -key qa-key.pem -out qa.csr \
-  -subj "/CN=qa-team/OU=viewer"
+# Developers (developer access)
+openssl req -new -key dev-key.pem -out dev.csr \
+  -subj "/CN=developer/OU=developer"
+
+# Reporting/observability (reader access)
+openssl req -new -key report-key.pem -out report.csr \
+  -subj "/CN=reporting/OU=reader"
 
 # Sign all certificates with CA
-for cert in devops dev qa; do
+for cert in devops cicd dev report; do
   openssl x509 -req -in ${cert}.csr -CA ca-cert.pem -CAkey ca-key.pem \
     -out ${cert}-cert.pem -days 365 -CAcreateserial
 done
-```
-
-### Fine-Grained Permissions (Future)
-
-Current RBAC is binary (admin/viewer). For more granular control:
-
-```yaml
-# Conceptual fine-grained permissions
-authorization:
-  roles:
-    admin:
-      - job:*
-      - volume:*
-      - network:*
-      - monitor:*
-
-    developer:
-      - job:run
-      - job:list
-      - job:status
-      - job:logs
-      - volume:list
-
-    qa:
-      - job:list
-      - job:status
-      - job:logs
-      - monitor:status
 ```
 
 ## Process Isolation
@@ -751,7 +792,7 @@ sudo grep "auth_success" /var/log/joblet/audit.log | tail -1000
 ### ✅ Do's
 
 1. **Always use mTLS** - Never disable certificate verification
-2. **Implement RBAC** - Use viewer certificates for read-only access
+2. **Implement RBAC** - Give each user the least-privileged role (reader for read-only access)
 3. **Network isolation** - Use custom networks for sensitive workloads
 4. **Resource limits** - Always set appropriate CPU/memory limits
 5. **Audit logging** - Enable comprehensive security logging
@@ -766,7 +807,7 @@ sudo grep "auth_success" /var/log/joblet/audit.log | tail -1000
 3. **Don't disable TLS** in production
 4. **Don't use unlimited resources** for untrusted jobs
 5. **Don't ignore audit logs** - Monitor for anomalies
-6. **Don't share admin certificates** - Use viewer certificates for most users
+6. **Don't share admin certificates** - Use maintainer, developer, or reader certificates for most users
 7. **Don't run Joblet as non-root** - It needs privileges for isolation
 8. **Don't trust user input** - Validate and sanitize all inputs
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -522,19 +522,28 @@ openssl verify -CAfile ca-cert.pem client-cert.pem
 ### Permission Denied (RBAC)
 
 ```bash
-# Error: "permission denied" for admin operations
+# Error: "PermissionDenied: role developer is not allowed to perform operation create_network"
 
-# 1. Check client role
+# 1. Check the client role (carried in the certificate's OU field, case-insensitive)
 openssl x509 -in client-cert.pem -noout -subject
+```
 
-# 2. Should show OU=admin for admin operations
-# Generate admin certificate if needed
-openssl req -new -key client-key.pem -out admin.csr \
-  -subj "/CN=admin-client/OU=admin"
+The OU must be one of the four roles:
 
-# 3. Use viewer certificate for read-only
-openssl req -new -key client-key.pem -out viewer.csr \
-  -subj "/CN=viewer-client/OU=viewer"
+- `admin` - everything
+- `maintainer` - provision runtimes, networks, and volumes, and run jobs (no removals)
+- `developer` - run jobs, plus all reads
+- `reader` - reads only (`viewer` on older certificates means the same thing)
+
+Any other OU value fails every request.
+
+```bash
+# 2. Use a node with a sufficient role
+# The generated rnx-config.yml contains one node per role plus "default" (admin certificate)
+rnx --node admin volume remove old-data
+
+# 3. Regenerate role certificates if needed
+sudo /usr/local/bin/certs_gen_embedded.sh
 ```
 
 ### TLS Handshake Failure

--- a/docs/VOLUME_MANAGEMENT.md
+++ b/docs/VOLUME_MANAGEMENT.md
@@ -43,12 +43,12 @@ Each job runs in an isolated filesystem environment (chroot) and can **only see 
 ```mermaid
 flowchart TD
     subgraph JA["Job A (assigned: volume-a)"]
-        A1["/volumes/volume-a/ — ✓ accessible"]
-        A2["volume-b/ — ✗ not visible"]
+        A1["/volumes/volume-a/ (✓ accessible)"]
+        A2["volume-b/ (✗ not visible)"]
     end
     subgraph JB["Job B (assigned: volume-b)"]
-        B1["/volumes/volume-b/ — ✓ accessible"]
-        B2["volume-a/ — ✗ not visible"]
+        B1["/volumes/volume-b/ (✓ accessible)"]
+        B2["volume-a/ (✗ not visible)"]
     end
 ```
 

--- a/docs/adr/013-extract-workflow-to-separate-project.md
+++ b/docs/adr/013-extract-workflow-to-separate-project.md
@@ -216,7 +216,7 @@ YAML format, provide migration scripts.
 - Geographic distribution
 - Failure domain isolation
 
-**Unified execution backend**: The orchestrator targets joblet as its execution backend everywhere — local,
+**Unified execution backend**: The orchestrator targets joblet as its execution backend everywhere: local,
 cloud, and multi-node. Because joblet provides isolation, resource limits, GPU allocation, and networking natively
 through Linux kernel primitives, the orchestrator gets one consistent execution surface across environments without
 having to special-case container runtimes or remote-shell transports.
@@ -250,7 +250,7 @@ Don't build our own orchestrator. Document how to drive joblet from an off-the-s
 
 **Rejected**: A first-party orchestrator that speaks joblet's Job API natively gives users a cohesive, supported
 experience out of the box. Extracting workflows into `joblet-orchestrator` still keeps the Job API open, so teams
-with an existing orchestration layer can integrate — but joblet ships a complete solution rather than deferring to
+with an existing orchestration layer can integrate, but joblet ships a complete solution rather than deferring to
 external tooling.
 
 ## Implementation Notes

--- a/docs/adr/014-ebpf-runtime-visibility.md
+++ b/docs/adr/014-ebpf-runtime-visibility.md
@@ -158,7 +158,7 @@ type FileData struct {
 
 ```mermaid
 flowchart TD
-    subgraph JOBLET["JOBLET (core binary) — Native Linux only, no AWS SDK"]
+    subgraph JOBLET["JOBLET (core binary): Native Linux only, no AWS SDK"]
         N1["Metrics Collector (cgroups v2)"]
         N2["eBPF Monitor (cilium/ebpf)"]
         N3["Telemetry Collector<br/>- Unify events<br/>- Buffer/batch"]
@@ -169,7 +169,7 @@ flowchart TD
         N3 --> N4
         N3 --> N5
     end
-    subgraph PERSIST["PERSIST (separate binary) — May have AWS SDK if configured"]
+    subgraph PERSIST["PERSIST (separate binary): May have AWS SDK if configured"]
         N6["Local Storage"]
         N7["CloudWatch (optional)"]
     end

--- a/docs/adr/015-four-role-authorization.md
+++ b/docs/adr/015-four-role-authorization.md
@@ -1,0 +1,94 @@
+# ADR-015: Four-Role Authorization Model
+
+## Status
+
+**Implemented** (July 2026)
+
+## Context
+
+Joblet authorizes gRPC clients by mapping the mTLS client certificate's
+Organizational Unit (OU) to a role. The original model had two roles: `admin`
+(everything) and `viewer` (read-only). Real deployments have more than two
+kinds of clients:
+
+- People who administer nodes and own shared infrastructure.
+- CI/CD automation that provisions runtimes, networks, and volumes
+  declaratively and must not acquire destructive permissions along the way.
+- Engineers who run jobs but have no reason to modify shared infrastructure.
+- Reporting and observability tooling that only reads logs and telemetry.
+
+The two-role model forced the middle two groups into `admin`. The gap was
+amplified by the operation vocabulary: although granular operation constants
+existed (`create_network`, `create_volume`, ...), the services gated volume,
+network, and runtime mutation behind the generic `run_job` operation, so any
+client that could run a job could also build or remove every runtime, network,
+and volume on the node. Monitoring endpoints performed no role check at all:
+any certificate signed by the CA could stream system metrics.
+
+## Decision
+
+Adopt four roles, carried in the client certificate OU (case-insensitive):
+
+| Role         | Intended for                           | Permissions                                                                                          |
+|--------------|----------------------------------------|------------------------------------------------------------------------------------------------------|
+| `admin`      | Operators who own the node             | All operations, including removing runtimes, networks, and volumes                                   |
+| `maintainer` | Automation with deterministic outcomes | Everything developer can do, plus build runtimes, validate runtime YAML, create networks and volumes |
+| `developer`  | Engineers running jobs                 | Run, stop, and delete jobs; test runtimes; all read operations                                       |
+| `reader`     | Reporting and observability            | Read-only: jobs, logs, status, runtime/network/volume listings, live metrics, historical queries     |
+
+Supporting decisions:
+
+- **Removal is admin-only.** Maintainer provisions but never destroys shared
+  infrastructure. Removing a runtime, network, or volume affects every user of
+  the node and stays with the operator who owns it.
+- **`viewer` remains a legacy alias for `reader`.** Existing certificates keep
+  working; new certificates use `reader`.
+- **Every service checks an operation that names what it does.** Volume,
+  network, runtime, and monitoring handlers now pass their own operations
+  (`create_volume`, `remove_network`, `build_runtime`, `get_metrics`, ...)
+  instead of borrowing job operations. Roles are defined as cumulative
+  operation sets (reader ⊂ developer ⊂ maintainer ⊂ admin) in
+  `internal/joblet/auth/grpc_authorization.go`.
+- **Monitoring requires a role.** `GetSystemStatus` and `StreamSystemMetrics`
+  authorize against `get_metrics`, which every role holds; a certificate with
+  no recognized role OU is denied.
+- **Both installers generate all four roles and per-role distribution
+  artifacts.** `certs_gen_embedded.sh` and `certs_gen_with_secretsmanager.sh`
+  produce one client certificate per role, an operator `rnx-config.yml` with
+  every role's node (admin key included, so it stays on the server), and one
+  self-contained `rnx-config-<role>.yml` per role for handing to that role's
+  users. The config file is the credential; role separation only holds if each
+  party receives only its own file. The AWS variant also stores each role's
+  pair in Secrets Manager as `joblet/client-cert-<role>` and
+  `joblet/client-key-<role>`, so client IAM policies can be scoped per role.
+  The pre-existing unsuffixed `joblet/client-cert` and `joblet/client-key`
+  names continue to hold the admin pair, keeping existing deployments and the
+  `pre-setup.sh` seeding flow working unchanged.
+
+Authorization remains method-level: a role either may or may not call an
+operation. Constraining *which* runtimes, networks, or volumes a developer job
+may reference is argument-level policy and is out of scope for this decision.
+
+## Consequences
+
+**Positive:**
+
+- Automation credentials no longer imply destructive power; a leaked
+  maintainer certificate cannot remove runtimes, networks, or volumes.
+- Job-running credentials no longer imply infrastructure mutation.
+- Read-only integrations (dashboards, reporting) have a first-class role, and
+  monitoring endpoints are inside the authorization model.
+- The operation vocabulary matches service behavior, so future per-operation
+  decisions are one-line changes to a role's operation set.
+
+**Negative:**
+
+- Existing admin certificates used by automation should be reissued as
+  `maintainer` or `developer` to realize the benefit; nothing forces this.
+- Clients holding admin certificates for convenience lose nothing, so the
+  migration relies on operators adopting the narrower roles.
+
+**Neutral:**
+
+- The role boundary is only as strong as job sandboxing underneath it; mount
+  and privilege hardening are tracked independently of this decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,21 +25,22 @@ Each ADR follows this structure:
 
 ## ADR Index
 
-| Number                                             | Title                                       | Status      | Date       |
-|----------------------------------------------------|---------------------------------------------|-------------|------------|
-| [001](001-two-stage-execution-pattern.md)          | Two-Stage Execution Pattern                 | Accepted    | 2024-09-22 |
-| [003](003-namespace-isolation-strategy.md)         | Namespace Isolation Strategy                | Accepted    | 2024-09-22 |
-| [004](004-self-contained-runtime-architecture.md)  | Self-Contained Runtime Architecture         | Accepted    | 2025-09-*  |
-| [005](005-async-log-persistence.md)                | Async Log Persistence                       | Accepted    | 2024-09-22 |
-| [006](006-embedded-certificates.md)                | Embedded Certificates                       | Accepted    | 2024-09-22 |
-| [007](007-cgroups-v2-resource-management.md)       | cgroups v2 Resource Management              | Accepted    | 2024-09-22 |
-| [008](008-gpu-support-architecture.md)             | GPU Support Architecture                    | Accepted    | 2024-09-*  |
-| [009](009-seccomp-syscall-filtering.md)            | Seccomp Syscall Filtering                   | Proposed    | 2024-09-*  |
-| [010](010-collect-jobs-metrics.md)                 | Collect Jobs Metrics                        | Accepted    | 2024-10-*  |
+| Number                                              | Title                                       | Status      | Date       |
+|-----------------------------------------------------|---------------------------------------------|-------------|------------|
+| [001](001-two-stage-execution-pattern.md)           | Two-Stage Execution Pattern                 | Accepted    | 2024-09-22 |
+| [003](003-namespace-isolation-strategy.md)          | Namespace Isolation Strategy                | Accepted    | 2024-09-22 |
+| [004](004-self-contained-runtime-architecture.md)   | Self-Contained Runtime Architecture         | Accepted    | 2025-09-*  |
+| [005](005-async-log-persistence.md)                 | Async Log Persistence                       | Accepted    | 2024-09-22 |
+| [006](006-embedded-certificates.md)                 | Embedded Certificates                       | Accepted    | 2024-09-22 |
+| [007](007-cgroups-v2-resource-management.md)        | cgroups v2 Resource Management              | Accepted    | 2024-09-22 |
+| [008](008-gpu-support-architecture.md)              | GPU Support Architecture                    | Accepted    | 2024-09-*  |
+| [009](009-seccomp-syscall-filtering.md)             | Seccomp Syscall Filtering                   | Proposed    | 2024-09-*  |
+| [010](010-collect-jobs-metrics.md)                  | Collect Jobs Metrics                        | Accepted    | 2024-10-*  |
 | [011](011-cqrs-architecture-with-joblet-persist.md) | CQRS Architecture with persist Service      | Accepted    | 2025-10-*  |
-| [012](012-aws-secrets-manager-cert-storage.md)     | AWS Secrets Manager for Certificate Storage | Accepted    | 2025-10-*  |
-| [013](013-extract-workflow-to-separate-project.md) | Extract Workflow to Separate Project        | Implemented | 2025-12-03 |
-| [014](014-ebpf-runtime-visibility.md)              | Unified Job Telemetry with eBPF Telematics  | Implemented | 2025-12-04 |
+| [012](012-aws-secrets-manager-cert-storage.md)      | AWS Secrets Manager for Certificate Storage | Accepted    | 2025-10-*  |
+| [013](013-extract-workflow-to-separate-project.md)  | Extract Workflow to Separate Project        | Implemented | 2025-12-03 |
+| [014](014-ebpf-runtime-visibility.md)               | Unified Job Telemetry with eBPF Telematics  | Implemented | 2025-12-04 |
+| [015](015-four-role-authorization.md)               | Four-Role Authorization Model               | Implemented | 2026-07-23 |
 
 ## Creating a New ADR
 

--- a/internal/joblet/adapters/job_store_adapter.go
+++ b/internal/joblet/adapters/job_store_adapter.go
@@ -498,37 +498,49 @@ func (a *jobStoreAdapter) SendUpdatesToClientWithSkip(ctx context.Context, id st
 	isCompleted := task.job.IsCompleted()
 	a.tasksMutex.RUnlock()
 
-	// Send existing buffer content, skipping items already sent by persist
-	// ONLY when persist is enabled - otherwise skip buffer entirely to avoid stale data
-	if a.persistEnabled && logBuffer != nil {
-		var chunks [][]byte
-		if skipCount > 0 {
-			chunks = logBuffer.ReadAfterSkip(skipCount)
-			a.logger.Debug("reading buffer with skip", "job_uuid", id, "skipCount", skipCount, "remainingChunks", len(chunks))
-		} else {
-			chunks = logBuffer.ReadAll()
-		}
-
-		if len(chunks) > 0 {
-			for _, chunk := range chunks {
-				if err := stream.SendData(chunk); err != nil {
-					a.logger.Warn("failed to send existing log chunk", "job_uuid", id, "error", err)
-					return err
-				}
+	// sendBuffered sends the buffer snapshot, skipping items already sent by
+	// persist. ONLY when persist is enabled - otherwise skip buffer entirely
+	// to avoid stale data
+	sendBuffered := func() error {
+		if a.persistEnabled && logBuffer != nil {
+			var chunks [][]byte
+			if skipCount > 0 {
+				chunks = logBuffer.ReadAfterSkip(skipCount)
+				a.logger.Debug("reading buffer with skip", "job_uuid", id, "skipCount", skipCount, "remainingChunks", len(chunks))
+			} else {
+				chunks = logBuffer.ReadAll()
 			}
-			a.logger.Debug("sent existing logs", "job_uuid", id, "chunkCount", len(chunks), "skipped", skipCount)
+
+			if len(chunks) > 0 {
+				for _, chunk := range chunks {
+					if err := stream.SendData(chunk); err != nil {
+						a.logger.Warn("failed to send existing log chunk", "job_uuid", id, "error", err)
+						return err
+					}
+				}
+				a.logger.Debug("sent existing logs", "job_uuid", id, "chunkCount", len(chunks), "skipped", skipCount)
+			}
+		} else if !a.persistEnabled {
+			a.logger.Debug("persist disabled - skipping buffer read (live streaming only)", "job_uuid", id)
 		}
-	} else if !a.persistEnabled {
-		a.logger.Debug("persist disabled - skipping buffer read (live streaming only)", "job_uuid", id)
+		return nil
 	}
 
-	// If job is completed, we're done
+	// If job is completed, send the buffer and we're done
 	if isCompleted {
+		if err := sendBuffered(); err != nil {
+			return err
+		}
 		a.logger.Debug("job is completed, finishing stream", "job_uuid", id)
 		return nil
 	}
 
-	return a.subscribeToJobUpdates(ctx, resolvedUuid, stream)
+	// Running job: subscribe BEFORE sending the buffer snapshot. Lines
+	// published while the snapshot is in flight queue up in the subscription
+	// channel instead of falling into the seam between snapshot and
+	// subscription - that seam silently lost lines; the overlap this creates
+	// only produces duplicates, which clients tolerate.
+	return a.subscribeToJobUpdates(ctx, resolvedUuid, stream, sendBuffered)
 }
 
 // PubSub returns the pub-sub instance for external integration (e.g., IPC)
@@ -885,7 +897,11 @@ func (a *jobStoreAdapter) publishEvent(event JobEvent) error {
 // subscribeToJobUpdates creates a real-time subscription for job events.
 // Handles LOG_CHUNK events by streaming data to client, and UPDATED events by checking
 // for job completion. Manages subscription lifecycle and cleanup automatically.
-func (a *jobStoreAdapter) subscribeToJobUpdates(ctx context.Context, jobUUID string, stream interfaces.DomainStreamer) error {
+// sendBuffered, when non-nil, is invoked after the subscription is
+// established but before live events are pumped, so the pre-subscription
+// snapshot reaches the client first and nothing falls between snapshot
+// and subscription.
+func (a *jobStoreAdapter) subscribeToJobUpdates(ctx context.Context, jobUUID string, stream interfaces.DomainStreamer, sendBuffered func() error) error {
 	// Subscribe to single "jobs" topic (filter by JobUUID in loop)
 	topic := "jobs"
 	a.logger.Debug("subscribing to job events for streaming", "job_uuid", jobUUID, "topic", topic)
@@ -923,6 +939,23 @@ func (a *jobStoreAdapter) subscribeToJobUpdates(ctx context.Context, jobUUID str
 	task.subscribers[subID] = subContext
 	task.subMutex.Unlock()
 	a.tasksMutex.RUnlock()
+
+	// Subscription is live: deliver the buffer snapshot first so output stays
+	// ordered. Events published meanwhile accumulate in the updates channel.
+	if sendBuffered != nil {
+		if err := sendBuffered(); err != nil {
+			unsubscribe()
+			cancel()
+			a.tasksMutex.RLock()
+			if task, exists := a.tasks[jobUUID]; exists {
+				task.subMutex.Lock()
+				delete(task.subscribers, subID)
+				task.subMutex.Unlock()
+			}
+			a.tasksMutex.RUnlock()
+			return err
+		}
+	}
 
 	// Create a channel to signal when subscription ends
 	done := make(chan error, 1)

--- a/internal/joblet/auth/grpc_authorization.go
+++ b/internal/joblet/auth/grpc_authorization.go
@@ -16,8 +16,20 @@ import (
 type ClientRole string
 
 const (
-	AdminRole   ClientRole = "admin"
-	ViewerRole  ClientRole = "viewer"
+	// AdminRole can perform every operation, including destructive ones
+	// (removing runtimes, networks, and volumes).
+	AdminRole ClientRole = "admin"
+	// MaintainerRole is intended for automation with deterministic outcomes:
+	// it can provision infrastructure (build runtimes, create networks and
+	// volumes) and run jobs, but cannot remove shared infrastructure.
+	MaintainerRole ClientRole = "maintainer"
+	// DeveloperRole runs jobs using existing runtimes, networks, and volumes,
+	// but cannot create or remove infrastructure.
+	DeveloperRole ClientRole = "developer"
+	// ReaderRole has read-only access to jobs, logs, and telemetry, for
+	// reporting and observability. Certificates with OU "viewer" (the
+	// pre-four-role name) map to this role.
+	ReaderRole  ClientRole = "reader"
 	UnknownRole ClientRole = "unknown"
 )
 
@@ -30,7 +42,6 @@ const (
 	StopJobOp      Operation = "stop_job"
 	DeleteJobOp    Operation = "delete_job"
 	ListJobsOp     Operation = "list_jobs"
-	StreamJobsOp   Operation = "stream_jobs"
 	GetJobLogsOp   Operation = "get_job_logs"
 	GetJobStatusOp Operation = "get_job_status"
 
@@ -44,10 +55,55 @@ const (
 	ListVolumesOp  Operation = "list_volumes"
 	RemoveVolumeOp Operation = "remove_volume"
 
+	// Runtime operations
+	ListRuntimesOp    Operation = "list_runtimes"
+	GetRuntimeInfoOp  Operation = "get_runtime_info"
+	TestRuntimeOp     Operation = "test_runtime"
+	ValidateRuntimeOp Operation = "validate_runtime"
+	BuildRuntimeOp    Operation = "build_runtime"
+	RemoveRuntimeOp   Operation = "remove_runtime"
+
+	// Monitoring operations (live system metrics)
+	GetMetricsOp Operation = "get_metrics"
+
 	// Persist operations (historical data queries)
 	QueryLogsOp    Operation = "query_logs"
 	QueryMetricsOp Operation = "query_metrics"
 )
+
+// readOps are available to every role, including reader.
+var readOps = []Operation{
+	GetJobOp, ListJobsOp, GetJobLogsOp, GetJobStatusOp,
+	ListNetworksOp, ListVolumesOp,
+	ListRuntimesOp, GetRuntimeInfoOp,
+	GetMetricsOp, QueryLogsOp, QueryMetricsOp,
+}
+
+// developerOps adds job execution on top of read access.
+var developerOps = append([]Operation{
+	RunJobOp, StopJobOp, DeleteJobOp, TestRuntimeOp,
+}, readOps...)
+
+// maintainerOps adds infrastructure provisioning on top of job execution.
+// Removal of shared infrastructure stays admin-only.
+var maintainerOps = append([]Operation{
+	BuildRuntimeOp, ValidateRuntimeOp, CreateNetworkOp, CreateVolumeOp,
+}, developerOps...)
+
+// AdminRole is not listed: it is allowed everything.
+var roleOperations = map[ClientRole]map[Operation]bool{
+	ReaderRole:     opSet(readOps),
+	DeveloperRole:  opSet(developerOps),
+	MaintainerRole: opSet(maintainerOps),
+}
+
+func opSet(ops []Operation) map[Operation]bool {
+	set := make(map[Operation]bool, len(ops))
+	for _, op := range ops {
+		set[op] = true
+	}
+	return set
+}
 
 //counterfeiter:generate . GRPCAuthorization
 type GRPCAuthorization interface {
@@ -94,51 +150,45 @@ func (s *grpcAuthorization) extractClientRole(ctx context.Context) (ClientRole, 
 
 	clientCert := tlsInfo.State.PeerCertificates[0]
 
-	// extractClientRole extracts role from Organizational Unit (OU)
+	// A certificate carrying more than one role OU gets the least privileged
+	// of them, so an ambiguous certificate can never escalate.
+	role := UnknownRole
 	for _, ou := range clientCert.Subject.OrganizationalUnit {
+		var candidate ClientRole
 		switch strings.ToLower(ou) {
 		case "admin":
-			return AdminRole, nil
-		case "viewer":
-			return ViewerRole, nil
+			candidate = AdminRole
+		case "maintainer":
+			candidate = MaintainerRole
+		case "developer":
+			candidate = DeveloperRole
+		case "reader", "viewer": // "viewer" is the pre-four-role name
+			candidate = ReaderRole
+		default:
+			continue
+		}
+		if role == UnknownRole || rolePrivilege[candidate] < rolePrivilege[role] {
+			role = candidate
 		}
 	}
 
-	// Clients must have explicit "admin" or "viewer" in certificate OU
-	return UnknownRole, nil
+	return role, nil
+}
+
+// rolePrivilege orders roles for least-privilege selection when a certificate
+// carries more than one role OU.
+var rolePrivilege = map[ClientRole]int{
+	ReaderRole:     1,
+	DeveloperRole:  2,
+	MaintainerRole: 3,
+	AdminRole:      4,
 }
 
 func (s *grpcAuthorization) isOperationAllowed(role ClientRole, operation Operation) bool {
-	switch role {
-	case AdminRole:
-		// Admin can perform all operations
+	if role == AdminRole {
 		return true
-	case ViewerRole:
-		switch operation {
-		// Job operations - viewers can read but not modify
-		case GetJobOp, ListJobsOp, StreamJobsOp, GetJobLogsOp, GetJobStatusOp:
-			return true
-		case RunJobOp, StopJobOp, DeleteJobOp:
-			return false
-		// Network operations - viewers can list but not create/remove
-		case ListNetworksOp:
-			return true
-		case CreateNetworkOp, RemoveNetworkOp:
-			return false
-		// Volume operations - viewers can list but not create/remove
-		case ListVolumesOp:
-			return true
-		case CreateVolumeOp, RemoveVolumeOp:
-			return false
-		// Persist operations - viewers can query historical data (read-only)
-		case QueryLogsOp, QueryMetricsOp:
-			return true
-		default:
-			return false
-		}
-	default:
-		return false
 	}
+	return roleOperations[role][operation]
 }
 
 func (s *grpcAuthorization) Authorized(ctx context.Context, operation Operation) error {

--- a/internal/joblet/auth/grpc_authorization_test.go
+++ b/internal/joblet/auth/grpc_authorization_test.go
@@ -78,9 +78,27 @@ func TestGrpcAuthorization_ExtractClientRole(t *testing.T) {
 			expectError:  false,
 		},
 		{
-			name:         "Viewer role",
+			name:         "Maintainer role",
+			context:      createMockContext([]string{"maintainer"}),
+			expectedRole: MaintainerRole,
+			expectError:  false,
+		},
+		{
+			name:         "Developer role",
+			context:      createMockContext([]string{"developer"}),
+			expectedRole: DeveloperRole,
+			expectError:  false,
+		},
+		{
+			name:         "Reader role",
+			context:      createMockContext([]string{"reader"}),
+			expectedRole: ReaderRole,
+			expectError:  false,
+		},
+		{
+			name:         "Viewer maps to reader (legacy alias)",
 			context:      createMockContext([]string{"viewer"}),
-			expectedRole: ViewerRole,
+			expectedRole: ReaderRole,
 			expectError:  false,
 		},
 		{
@@ -92,13 +110,25 @@ func TestGrpcAuthorization_ExtractClientRole(t *testing.T) {
 		{
 			name:         "Viewer role (case insensitive)",
 			context:      createMockContext([]string{"VIEWER"}),
-			expectedRole: ViewerRole,
+			expectedRole: ReaderRole,
 			expectError:  false,
 		},
 		{
 			name:         "Multiple OUs with admin",
 			context:      createMockContext([]string{"something", "admin", "other"}),
 			expectedRole: AdminRole,
+			expectError:  false,
+		},
+		{
+			name:         "Multiple role OUs resolve to least privileged",
+			context:      createMockContext([]string{"admin", "reader"}),
+			expectedRole: ReaderRole,
+			expectError:  false,
+		},
+		{
+			name:         "Maintainer and developer OUs resolve to developer",
+			context:      createMockContext([]string{"developer", "maintainer"}),
+			expectedRole: DeveloperRole,
 			expectError:  false,
 		},
 		{
@@ -161,26 +191,68 @@ func TestGrpcAuthorization_IsOperationAllowed(t *testing.T) {
 		operation Operation
 		allowed   bool
 	}{
-		// Admin role - should allow all operations
+		// Admin role - should allow all operations, including destructive ones
 		{AdminRole, RunJobOp, true},
 		{AdminRole, GetJobOp, true},
 		{AdminRole, StopJobOp, true},
 		{AdminRole, ListJobsOp, true},
-		{AdminRole, StreamJobsOp, true},
+		{AdminRole, RemoveRuntimeOp, true},
+		{AdminRole, RemoveNetworkOp, true},
+		{AdminRole, RemoveVolumeOp, true},
 
-		// Viewer role - should allow only read operations
-		{ViewerRole, RunJobOp, false},
-		{ViewerRole, GetJobOp, true},
-		{ViewerRole, StopJobOp, false},
-		{ViewerRole, ListJobsOp, true},
-		{ViewerRole, StreamJobsOp, true},
+		// Maintainer role - provisioning and jobs, but no removal of shared infrastructure
+		{MaintainerRole, RunJobOp, true},
+		{MaintainerRole, BuildRuntimeOp, true},
+		{MaintainerRole, ValidateRuntimeOp, true},
+		{MaintainerRole, CreateNetworkOp, true},
+		{MaintainerRole, CreateVolumeOp, true},
+		{MaintainerRole, GetJobOp, true},
+		{MaintainerRole, RemoveRuntimeOp, false},
+		{MaintainerRole, RemoveNetworkOp, false},
+		{MaintainerRole, RemoveVolumeOp, false},
+
+		// Developer role - job execution on existing infrastructure only
+		{DeveloperRole, RunJobOp, true},
+		{DeveloperRole, StopJobOp, true},
+		{DeveloperRole, DeleteJobOp, true},
+		{DeveloperRole, TestRuntimeOp, true},
+		{DeveloperRole, GetJobOp, true},
+		{DeveloperRole, ListRuntimesOp, true},
+		{DeveloperRole, ListNetworksOp, true},
+		{DeveloperRole, ListVolumesOp, true},
+		{DeveloperRole, BuildRuntimeOp, false},
+		{DeveloperRole, ValidateRuntimeOp, false},
+		{DeveloperRole, CreateNetworkOp, false},
+		{DeveloperRole, CreateVolumeOp, false},
+		{DeveloperRole, RemoveRuntimeOp, false},
+		{DeveloperRole, RemoveNetworkOp, false},
+		{DeveloperRole, RemoveVolumeOp, false},
+
+		// Reader role - should allow only read operations
+		{ReaderRole, RunJobOp, false},
+		{ReaderRole, GetJobOp, true},
+		{ReaderRole, StopJobOp, false},
+		{ReaderRole, DeleteJobOp, false},
+		{ReaderRole, ListJobsOp, true},
+		{ReaderRole, GetJobLogsOp, true},
+		{ReaderRole, GetJobStatusOp, true},
+		{ReaderRole, ListRuntimesOp, true},
+		{ReaderRole, GetRuntimeInfoOp, true},
+		{ReaderRole, ListNetworksOp, true},
+		{ReaderRole, ListVolumesOp, true},
+		{ReaderRole, GetMetricsOp, true},
+		{ReaderRole, QueryLogsOp, true},
+		{ReaderRole, QueryMetricsOp, true},
+		{ReaderRole, TestRuntimeOp, false},
+		{ReaderRole, BuildRuntimeOp, false},
+		{ReaderRole, CreateNetworkOp, false},
+		{ReaderRole, CreateVolumeOp, false},
 
 		// Unknown role - should not allow any operations
 		{UnknownRole, RunJobOp, false},
 		{UnknownRole, GetJobOp, false},
 		{UnknownRole, StopJobOp, false},
 		{UnknownRole, ListJobsOp, false},
-		{UnknownRole, StreamJobsOp, false},
 	}
 
 	for _, tt := range tests {
@@ -229,9 +301,9 @@ func TestGrpcAuthorization_Authorized(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "Admin can stream jobs",
+			name:        "Admin can read job logs",
 			context:     createMockContext([]string{"admin"}),
-			operation:   StreamJobsOp,
+			operation:   GetJobLogsOp,
 			expectError: false,
 		},
 		{
@@ -247,9 +319,9 @@ func TestGrpcAuthorization_Authorized(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "Viewer can stream jobs",
+			name:        "Viewer can read job logs",
 			context:     createMockContext([]string{"viewer"}),
-			operation:   StreamJobsOp,
+			operation:   GetJobLogsOp,
 			expectError: false,
 		},
 		{
@@ -329,7 +401,9 @@ func TestClientRole_String(t *testing.T) {
 		expected string
 	}{
 		{AdminRole, "admin"},
-		{ViewerRole, "viewer"},
+		{MaintainerRole, "maintainer"},
+		{DeveloperRole, "developer"},
+		{ReaderRole, "reader"},
 		{UnknownRole, "unknown"},
 	}
 
@@ -349,7 +423,6 @@ func TestOperation_String(t *testing.T) {
 		{GetJobOp, "get_job"},
 		{StopJobOp, "stop_job"},
 		{ListJobsOp, "list_jobs"},
-		{StreamJobsOp, "stream_jobs"},
 	}
 
 	for _, tt := range tests {

--- a/internal/joblet/core/environment/builder.go
+++ b/internal/joblet/core/environment/builder.go
@@ -3,17 +3,47 @@ package environment
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ehsaniara/joblet/internal/joblet/domain"
+	"github.com/ehsaniara/joblet/pkg/config"
 	"github.com/ehsaniara/joblet/pkg/logger"
 	"github.com/ehsaniara/joblet/pkg/platform"
 )
+
+// FilterServerConfigEnv removes server config path variables from an
+// environment destined for a job: they reference host files that do not
+// exist inside the job filesystem, and the init process must fall back to
+// built-in defaults instead of failing on them.
+func FilterServerConfigEnv(env []string) []string {
+	filtered := env[:0:0]
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "JOBLET_CONFIG_PATH=") || strings.HasPrefix(kv, "JOBLET_RUNTIME_CONFIG_PATH=") {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	return filtered
+}
+
+// ForwardFilesystemEnv renders the server's effective filesystem settings as
+// JOB_FS_* environment variables for the job init process. Init cannot (and
+// must not) read the server config file; these variables carry the loaded
+// in-memory values across the process boundary instead.
+func ForwardFilesystemEnv(fs *config.FilesystemConfig) []string {
+	return []string{
+		fmt.Sprintf("JOB_FS_WORKSPACE_DIR=%s", fs.WorkspaceDir),
+		fmt.Sprintf("JOB_FS_BASE_DIR=%s", fs.BaseDir),
+		fmt.Sprintf("JOB_FS_TMP_DIR=%s", fs.TmpDir),
+	}
+}
 
 // Builder handles environment variable construction for job execution
 type Builder struct {
 	platform      platform.Platform
 	uploadManager domain.UploadManager
+	config        *config.Config
 	logger        *logger.Logger
 }
 
@@ -21,11 +51,13 @@ type Builder struct {
 func NewBuilder(
 	platform platform.Platform,
 	uploadManager domain.UploadManager,
+	cfg *config.Config,
 	logger *logger.Logger,
 ) *Builder {
 	return &Builder{
 		platform:      platform,
 		uploadManager: uploadManager,
+		config:        cfg,
 		logger:        logger.WithField("component", "env-builder"),
 	}
 }
@@ -43,6 +75,8 @@ func (b *Builder) BuildJobEnvironment(config *JobEnvironmentConfig) ([]string, d
 	if config.BaseEnv == nil {
 		config.BaseEnv = b.platform.Environ()
 	}
+
+	config.BaseEnv = FilterServerConfigEnv(config.BaseEnv)
 
 	// Build core job environment
 	jobEnv := b.buildCoreEnvironment(config.Job, config.ExecutePath)
@@ -71,6 +105,12 @@ func (b *Builder) buildCoreEnvironment(job *domain.Job, execPath string) []strin
 		fmt.Sprintf("JOB_MAX_CPU=%d", job.Limits.CPU.Value()),
 		fmt.Sprintf("JOB_MAX_MEMORY=%d", job.Limits.Memory.Megabytes()),
 		fmt.Sprintf("JOB_MAX_IOBPS=%d", job.Limits.IOBandwidth.BytesPerSecond()),
+	}
+
+	// Forward the server's effective filesystem settings so init uses the
+	// loaded config values rather than assuming built-in defaults
+	if b.config != nil {
+		env = append(env, ForwardFilesystemEnv(&b.config.Filesystem)...)
 	}
 
 	if !job.Limits.CPUCores.IsEmpty() {

--- a/internal/joblet/core/execution/environment_service.go
+++ b/internal/joblet/core/execution/environment_service.go
@@ -42,7 +42,7 @@ func NewEnvironmentService(
 
 // BuildEnvironment builds the environment variables for a job
 func (es *EnvironmentService) BuildEnvironment(job *domain.Job, phase string) []string {
-	baseEnv := es.platform.Environ()
+	baseEnv := environment.FilterServerConfigEnv(es.platform.Environ())
 
 	jobEnv := []string{
 		"JOBLET_MODE=init",
@@ -56,6 +56,10 @@ func (es *EnvironmentService) BuildEnvironment(job *domain.Job, phase string) []
 		fmt.Sprintf("JOB_MAX_IOBPS=%d", job.Limits.IOBandwidth.BytesPerSecond()),
 		fmt.Sprintf("JOB_COMMAND=%s", job.Command),
 		fmt.Sprintf("JOB_ARGS_COUNT=%d", len(job.Args)),
+	}
+
+	if es.config != nil {
+		jobEnv = append(jobEnv, environment.ForwardFilesystemEnv(&es.config.Filesystem)...)
 	}
 
 	for i, arg := range job.Args {

--- a/internal/joblet/core/filesystem/isolator.go
+++ b/internal/joblet/core/filesystem/isolator.go
@@ -1147,11 +1147,9 @@ func (f *JobFilesystem) mountRuntimeWithManager(runtimeBasePath string) error {
 		Environment map[string]string `yaml:"environment"`
 	}
 
-	// Resolve the runtime spec to its directory, handling versioned runtimes
-	// like python-3.11@1.3.1 -> /opt/joblet/runtimes/python-3.11/1.3.1/.
-	// This validates the runtime even though submission already did: scheduled
-	// jobs can run long after submission, and the runtime may be gone or
-	// changed by then.
+	// Validates the runtime even though submission already did: scheduled jobs
+	// can run long after submission, and the runtime may be gone or changed by
+	// then.
 	runtimeResolver := runtime.NewResolver(runtimeBasePath, f.platform)
 	runtimeDir, _, err := runtimeResolver.ResolveRuntimeDirectory(f.Runtime)
 	if err != nil {

--- a/internal/joblet/core/job_executor.go
+++ b/internal/joblet/core/job_executor.go
@@ -54,7 +54,7 @@ func NewExecutionEngineV2(
 	gpuManager gpu.GPUManagerInterface,
 ) *ExecutionEngineV2 {
 	// Create environment builder
-	envBuilder := environment.NewBuilder(platform, uploadManager, logger)
+	envBuilder := environment.NewBuilder(platform, uploadManager, config, logger)
 
 	// Create environment service (runtime functionality now handled by filesystem isolator)
 	envService := execution.NewEnvironmentService(

--- a/internal/joblet/core/process/manager.go
+++ b/internal/joblet/core/process/manager.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ehsaniara/joblet/internal/joblet/core/environment"
 	"github.com/ehsaniara/joblet/internal/joblet/core/upload"
 	"github.com/ehsaniara/joblet/internal/joblet/domain"
 	"github.com/ehsaniara/joblet/pkg/config"
@@ -481,7 +482,7 @@ func (m *Manager) CreateSysProcAttr(enableNetworkNS bool) *syscall.SysProcAttr {
 
 // BuildJobEnvironment builds environment variables for a specific job
 func (m *Manager) BuildJobEnvironment(job *domain.Job, execPath string) []string {
-	baseEnv := m.platform.Environ()
+	baseEnv := environment.FilterServerConfigEnv(m.platform.Environ())
 
 	// Job-specific environment with mode indicator
 	jobEnv := []string{
@@ -502,6 +503,10 @@ func (m *Manager) BuildJobEnvironment(job *domain.Job, execPath string) []string
 		jobEnv = append(jobEnv, fmt.Sprintf("JOB_ARG_%d=%s", i, arg))
 	}
 
+	if m.config != nil {
+		jobEnv = append(jobEnv, environment.ForwardFilesystemEnv(&m.config.Filesystem)...)
+	}
+
 	return append(baseEnv, jobEnv...)
 }
 
@@ -510,7 +515,7 @@ func (m *Manager) PrepareEnvironment(baseEnv []string, jobEnvVars []string) []st
 	if baseEnv == nil {
 		baseEnv = m.platform.Environ()
 	}
-	return append(baseEnv, jobEnvVars...)
+	return append(environment.FilterServerConfigEnv(baseEnv), jobEnvVars...)
 }
 
 // IsProcessAlive checks if a process is still alive

--- a/internal/joblet/ebpf/telematics/bpf/telematics.c
+++ b/internal/joblet/ebpf/telematics/bpf/telematics.c
@@ -156,9 +156,13 @@ static __always_inline int is_monitored() {
     return marker != NULL;
 }
 
-// Tracepoint for execve syscall enter
-SEC("tracepoint/syscalls/sys_enter_execve")
-int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter *ctx) {
+// Tracepoint for successful exec (sched:sched_process_exec).
+// Fires after the kernel has resolved the binary, so the filename comes from
+// kernel memory via __data_loc and is always readable - unlike the user-space
+// pointer at sys_enter_execve, which fails when the page is not resident.
+// It also only fires for execs that succeeded, and comm is the new program.
+SEC("tracepoint/sched/sched_process_exec")
+int tracepoint__sched__sched_process_exec(struct trace_event_raw_sched_process_exec *ctx) {
     if (!is_monitored())
         return 0;
 
@@ -177,11 +181,13 @@ int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter *ctx
 
     bpf_get_current_comm(&event->comm, sizeof(event->comm));
 
-    // Read filename from syscall args
-    const char *filename = (const char *)ctx->args[0];
-    bpf_probe_read_user_str(&event->filename, sizeof(event->filename), filename);
+    // Filename lives inline in the event record; low 16 bits of the
+    // __data_loc field are the offset from the start of the record
+    __u32 fname_off = ctx->__data_loc_filename & 0xFFFF;
+    bpf_probe_read_kernel_str(&event->filename, sizeof(event->filename),
+                              (void *)ctx + fname_off);
 
-    event->retval = 0; // Will be set on exit
+    event->retval = 0; // sched_process_exec only fires on success
 
     bpf_ringbuf_submit(event, 0);
     return 0;

--- a/internal/joblet/ebpf/telematics/bpf/vmlinux.h
+++ b/internal/joblet/ebpf/telematics/bpf/vmlinux.h
@@ -132,6 +132,18 @@ struct trace_event_raw_sys_exit {
     long int ret;
 };
 
+// sched:sched_process_exec fires after a successful exec; the kernel stores
+// the resolved filename inline in the event record via a __data_loc offset
+struct trace_event_raw_sched_process_exec {
+    unsigned short common_type;
+    unsigned char common_flags;
+    unsigned char common_preempt_count;
+    int common_pid;
+    __u32 __data_loc_filename;
+    int pid;
+    int old_pid;
+};
+
 // __sk_buff for network helpers (stub, not used by our program)
 struct __sk_buff {
     __u32 len;

--- a/internal/joblet/ebpf/telematics/monitor.go
+++ b/internal/joblet/ebpf/telematics/monitor.go
@@ -193,12 +193,12 @@ func (m *Monitor) Start() error {
 	// Attach tracepoints based on configuration
 	goroutineCount := 0
 
-	// execve tracepoint (always attach if enabled)
+	// exec tracepoint (always attach if enabled)
 	if m.eventConfig.Exec {
-		execLink, err := link.Tracepoint("syscalls", "sys_enter_execve", m.objs.TracepointSyscallsSysEnterExecve, nil)
+		execLink, err := link.Tracepoint("sched", "sched_process_exec", m.objs.TracepointSchedSchedProcessExec, nil)
 		if err != nil {
 			m.objs.Close()
-			return fmt.Errorf("failed to attach execve tracepoint: %w", err)
+			return fmt.Errorf("failed to attach exec tracepoint: %w", err)
 		}
 		m.links = append(m.links, execLink)
 		goroutineCount++

--- a/internal/joblet/ebpf/telematics/telematics_arm64_bpfel.go
+++ b/internal/joblet/ebpf/telematics/telematics_arm64_bpfel.go
@@ -54,8 +54,8 @@ type telematicsSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type telematicsProgramSpecs struct {
+	TracepointSchedSchedProcessExec    *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSyscallsSysEnterConnect  *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_connect"`
-	TracepointSyscallsSysEnterExecve   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterMmap     *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_mmap"`
 	TracepointSyscallsSysEnterMprotect *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_mprotect"`
 	TracepointSyscallsSysEnterRecvfrom *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_recvfrom"`
@@ -133,8 +133,8 @@ type telematicsVariables struct {
 //
 // It can be passed to loadTelematicsObjects or ebpf.CollectionSpec.LoadAndAssign.
 type telematicsPrograms struct {
+	TracepointSchedSchedProcessExec    *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSyscallsSysEnterConnect  *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_connect"`
-	TracepointSyscallsSysEnterExecve   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterMmap     *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_mmap"`
 	TracepointSyscallsSysEnterMprotect *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_mprotect"`
 	TracepointSyscallsSysEnterRecvfrom *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_recvfrom"`
@@ -144,8 +144,8 @@ type telematicsPrograms struct {
 
 func (p *telematicsPrograms) Close() error {
 	return _TelematicsClose(
+		p.TracepointSchedSchedProcessExec,
 		p.TracepointSyscallsSysEnterConnect,
-		p.TracepointSyscallsSysEnterExecve,
 		p.TracepointSyscallsSysEnterMmap,
 		p.TracepointSyscallsSysEnterMprotect,
 		p.TracepointSyscallsSysEnterRecvfrom,

--- a/internal/joblet/ebpf/telematics/telematics_x86_bpfel.go
+++ b/internal/joblet/ebpf/telematics/telematics_x86_bpfel.go
@@ -54,8 +54,8 @@ type telematicsSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type telematicsProgramSpecs struct {
+	TracepointSchedSchedProcessExec    *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSyscallsSysEnterConnect  *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_connect"`
-	TracepointSyscallsSysEnterExecve   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterMmap     *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_mmap"`
 	TracepointSyscallsSysEnterMprotect *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_mprotect"`
 	TracepointSyscallsSysEnterRecvfrom *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_recvfrom"`
@@ -133,8 +133,8 @@ type telematicsVariables struct {
 //
 // It can be passed to loadTelematicsObjects or ebpf.CollectionSpec.LoadAndAssign.
 type telematicsPrograms struct {
+	TracepointSchedSchedProcessExec    *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSyscallsSysEnterConnect  *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_connect"`
-	TracepointSyscallsSysEnterExecve   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterMmap     *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_mmap"`
 	TracepointSyscallsSysEnterMprotect *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_mprotect"`
 	TracepointSyscallsSysEnterRecvfrom *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_recvfrom"`
@@ -144,8 +144,8 @@ type telematicsPrograms struct {
 
 func (p *telematicsPrograms) Close() error {
 	return _TelematicsClose(
+		p.TracepointSchedSchedProcessExec,
 		p.TracepointSyscallsSysEnterConnect,
-		p.TracepointSyscallsSysEnterExecve,
 		p.TracepointSyscallsSysEnterMmap,
 		p.TracepointSyscallsSysEnterMprotect,
 		p.TracepointSyscallsSysEnterRecvfrom,

--- a/internal/joblet/ipc/writer.go
+++ b/internal/joblet/ipc/writer.go
@@ -275,13 +275,12 @@ func (w *Writer) WriteFileEvent(event *ipcpb.FileEvent) error {
 	return w.write(msg)
 }
 
-// write sends a message with backpressure (blocks up to writeTimeout)
+// write sends a message with backpressure (blocks up to writeTimeout).
+// Messages are queued even while disconnected: the channel acts as a bounded
+// buffer during the persist warmup window and across reconnections, and
+// writeLoop delivers once the connection is up. Without this, everything a
+// job produces in the first seconds after service start is silently lost.
 func (w *Writer) write(msg *ipcpb.IPCMessage) error {
-	if !w.connected.Load() {
-		w.msgsDropped.Add(1)
-		return fmt.Errorf("not connected to persist service")
-	}
-
 	// Try non-blocking first for fast path
 	select {
 	case w.writeChan <- msg:
@@ -321,6 +320,14 @@ func (w *Writer) writeLoop() {
 		case <-w.ctx.Done():
 			return
 		case msg := <-w.writeChan:
+			// Hold the message until the connection is up (bounded wait) so
+			// queued messages survive the initial persist warmup and brief
+			// reconnections instead of being dropped
+			if !w.waitForConnection() {
+				w.msgsDropped.Add(1)
+				w.logger.Warn("Dropping message, persist unavailable past wait cap", "job_uuid", msg.JobUuid)
+				continue
+			}
 			if err := w.sendMessage(msg, lengthBuf); err != nil {
 				w.writeErrors.Add(1)
 				w.logger.Error("Failed to send IPC message", "error", err, "job_uuid", msg.JobUuid)
@@ -330,6 +337,33 @@ func (w *Writer) writeLoop() {
 				w.closeConnection()
 			} else {
 				w.msgsSent.Add(1)
+			}
+		}
+	}
+}
+
+// waitForConnection blocks until the writer is connected, a wait cap elapses,
+// or the writer shuts down. Returns true when connected.
+func (w *Writer) waitForConnection() bool {
+	if w.connected.Load() {
+		return true
+	}
+
+	const connectionWaitCap = 30 * time.Second
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.NewTimer(connectionWaitCap)
+	defer deadline.Stop()
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			return false
+		case <-deadline.C:
+			return false
+		case <-ticker.C:
+			if w.connected.Load() {
+				return true
 			}
 		}
 	}

--- a/internal/joblet/ipc/writer_test.go
+++ b/internal/joblet/ipc/writer_test.go
@@ -1,0 +1,99 @@
+package ipc
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	ipcpb "github.com/ehsaniara/joblet/internal/proto/gen/ipc"
+	"github.com/ehsaniara/joblet/pkg/logger"
+)
+
+// readIPCMessage reads one length-prefixed IPC message from the connection
+func readIPCMessage(t *testing.T, conn net.Conn) *ipcpb.IPCMessage {
+	t.Helper()
+
+	lengthBuf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, lengthBuf); err != nil {
+		t.Fatalf("failed to read length prefix: %v", err)
+	}
+	data := make([]byte, binary.BigEndian.Uint32(lengthBuf))
+	if _, err := io.ReadFull(conn, data); err != nil {
+		t.Fatalf("failed to read message body: %v", err)
+	}
+
+	msg := &ipcpb.IPCMessage{}
+	if err := proto.Unmarshal(data, msg); err != nil {
+		t.Fatalf("failed to unmarshal message: %v", err)
+	}
+	return msg
+}
+
+// TestWriterBuffersWhileDisconnected verifies that messages written before
+// persist is listening are queued and delivered once the connection is up,
+// instead of being dropped. This is the service-warmup window: the first job
+// after a restart produces logs before the ipc-writer has connected.
+func TestWriterBuffersWhileDisconnected(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "persist-test.sock")
+
+	w := NewWriter(&Config{
+		Socket:         socket,
+		BufferSize:     16,
+		ReconnectDelay: 50 * time.Millisecond,
+	}, logger.New())
+	defer w.Close()
+
+	// Persist is NOT up yet - this write must be accepted and buffered
+	if err := w.WriteLog("warmup-job", ipcpb.StreamType_STREAM_TYPE_STDOUT, 1, 1, []byte("early line")); err != nil {
+		t.Fatalf("write while disconnected should buffer, got error: %v", err)
+	}
+
+	// Bring persist up after the write
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("failed to listen on socket: %v", err)
+	}
+	defer listener.Close()
+
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			connCh <- conn
+		}
+	}()
+
+	var conn net.Conn
+	select {
+	case conn = <-connCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("writer did not connect to persist within 5s")
+	}
+	defer conn.Close()
+
+	// The buffered message must arrive
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
+	msg := readIPCMessage(t, conn)
+
+	if msg.JobUuid != "warmup-job" {
+		t.Errorf("expected buffered message for warmup-job, got %q", msg.JobUuid)
+	}
+	if msg.Type != ipcpb.MessageType_MESSAGE_TYPE_LOG {
+		t.Errorf("expected log message, got %v", msg.Type)
+	}
+
+	logLine := &ipcpb.LogLine{}
+	if err := proto.Unmarshal(msg.Data, logLine); err != nil {
+		t.Fatalf("failed to unmarshal log line: %v", err)
+	}
+	if string(logLine.Content) != "early line" {
+		t.Errorf("expected buffered content %q, got %q", "early line", string(logLine.Content))
+	}
+}

--- a/internal/joblet/runtime/resolver.go
+++ b/internal/joblet/runtime/resolver.go
@@ -181,8 +181,7 @@ func (r *Resolver) getDirectorySize(path string) (int64, error) {
 	return size, err
 }
 
-// ResolveRuntime resolves a runtime spec to config (for runtime info command)
-// This is a simplified version that just loads the config directly
+// ResolveRuntime resolves a runtime spec to its validated config
 func (r *Resolver) ResolveRuntime(runtimeSpec string) (*RuntimeConfig, error) {
 	if runtimeSpec == "" {
 		return nil, nil
@@ -192,10 +191,9 @@ func (r *Resolver) ResolveRuntime(runtimeSpec string) (*RuntimeConfig, error) {
 	return config, err
 }
 
-// ResolveRuntimeDirectory finds the directory for a runtime specification,
-// loads its runtime.yml, and validates it against this node (architecture
-// compatibility). Callers that only need one of the results can discard the
-// other; the config is always loaded and validated before either is returned.
+// ResolveRuntimeDirectory finds the directory for a runtime specification
+// (e.g. python-3.11@1.3.1 resolves to /opt/joblet/runtimes/python-3.11/1.3.1),
+// loads its runtime.yml, and validates it against this node's architecture.
 func (r *Resolver) ResolveRuntimeDirectory(runtimeSpec string) (string, *RuntimeConfig, error) {
 	runtimeDir, err := r.FindRuntimeDirectory(runtimeSpec)
 	if err != nil {

--- a/internal/joblet/server/grpc_server.go
+++ b/internal/joblet/server/grpc_server.go
@@ -81,7 +81,7 @@ func StartGRPCServer(jobStore adapters.JobStorer, telemetryCollector *telemetry.
 	pb.RegisterVolumeServiceServer(grpcServer, volumeService)
 
 	// Create and register monitoring service
-	monitoringGrpcService := NewMonitoringServiceServer(monitoringService, cfg)
+	monitoringGrpcService := NewMonitoringServiceServer(auth, monitoringService, cfg)
 	pb.RegisterMonitoringServiceServer(grpcServer, monitoringGrpcService)
 
 	// Create and register runtime service

--- a/internal/joblet/server/job_service.go
+++ b/internal/joblet/server/job_service.go
@@ -94,7 +94,6 @@ func (s *JobServiceServer) RunJob(ctx context.Context, req *pb.RunJobRequest) (*
 		}
 	}
 
-	// Convert protobuf request to domain request object
 	jobRequest, err := s.convertToJobRequest(req)
 	if err != nil {
 		log.Error("failed to convert request", "error", err)
@@ -142,7 +141,6 @@ func (s *JobServiceServer) RunJob(ctx context.Context, req *pb.RunJobRequest) (*
 	}, nil
 }
 
-// convertToJobRequest converts protobuf request to domain request object
 func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfaces.StartJobRequest, error) {
 	if req.Command == "" {
 		return nil, fmt.Errorf("%w: command is required", pkgerrors.ErrInvalidJobSpec)
@@ -174,7 +172,6 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 			"totalSize", totalSize)
 	}
 
-	// Determine job type from environment variables
 	jobType := domain.JobTypeStandard
 	if req.Environment != nil {
 		if envJobType, exists := req.Environment["JOB_TYPE"]; exists && envJobType == "runtime-build" {
@@ -212,7 +209,6 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 	return jobRequest, nil
 }
 
-// validateJobRequest validates the job request
 func (s *JobServiceServer) validateJobRequest(req *interfaces.StartJobRequest) error {
 	if req.Resources.MaxCPU < 0 {
 		return fmt.Errorf("maxCPU cannot be negative")
@@ -284,7 +280,7 @@ func (s *JobServiceServer) ListJobs(ctx context.Context, req *pb.EmptyRequest) (
 	log := s.logger.WithField("operation", "ListJobs")
 	log.Debug("list jobs request received")
 
-	if err := s.auth.Authorized(ctx, auth2.GetJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth2.ListJobsOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -305,7 +301,7 @@ func (s *JobServiceServer) GetJobStatus(ctx context.Context, req *pb.GetJobStatu
 	log := s.logger.WithFields("operation", "GetJobStatus", "job_uuid", req.GetUuid())
 	log.Debug("get job status request received")
 
-	if err := s.auth.Authorized(ctx, auth2.GetJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth2.GetJobStatusOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -388,7 +384,7 @@ func (s *JobServiceServer) DeleteJob(ctx context.Context, req *pb.DeleteJobReque
 	log := s.logger.WithFields("operation", "DeleteJob", "job_uuid", req.GetUuid())
 	log.Debug("delete job request received")
 
-	if err := s.auth.Authorized(ctx, auth2.StopJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth2.DeleteJobOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -423,7 +419,7 @@ func (s *JobServiceServer) DeleteAllJobs(ctx context.Context, req *pb.DeleteAllJ
 	log := s.logger.WithField("operation", "DeleteAllJobs")
 	log.Debug("delete all jobs request received")
 
-	if err := s.auth.Authorized(ctx, auth2.StopJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth2.DeleteJobOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -465,7 +461,7 @@ func (s *JobServiceServer) GetJobLogs(req *pb.GetJobLogsRequest, stream pb.JobSe
 	log := s.logger.WithFields("operation", "GetJobLogs", "job_uuid", req.GetUuid())
 	log.Debug("get job logs request received")
 
-	if err := s.auth.Authorized(stream.Context(), auth2.GetJobOp); err != nil {
+	if err := s.auth.Authorized(stream.Context(), auth2.GetJobLogsOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return err
 	}

--- a/internal/joblet/server/job_service.go
+++ b/internal/joblet/server/job_service.go
@@ -172,13 +172,17 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 			"totalSize", totalSize)
 	}
 
+	// SECURITY (issue #258): the isolation mode is a server-side decision and
+	// must never be derived from client input. Jobs submitted through RunJob
+	// always use standard (unprivileged) isolation; privileged runtime builds
+	// run through the dedicated, separately-authorized BuildRuntime RPC.
 	jobType := domain.JobTypeStandard
-	if req.Environment != nil {
-		if envJobType, exists := req.Environment["JOB_TYPE"]; exists && envJobType == "runtime-build" {
-			jobType = domain.JobTypeRuntimeBuild
-			s.logger.Info("detected runtime build job from environment", "envJobType", envJobType)
-		}
-	}
+
+	// Strip reserved control variables so a client cannot inject JOB_TYPE (or
+	// other trusted JOB_* vars) into the job process environment, which the
+	// in-namespace init reads to decide isolation behavior (see
+	// internal/modes/jobexec and internal/modes/isolation).
+	environment := sanitizeClientEnvironment(req.Environment)
 
 	jobRequest := &interfaces.StartJobRequest{
 		Command: req.Command,
@@ -194,7 +198,7 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 		Network:           network,
 		Volumes:           req.Volumes,
 		Runtime:           req.Runtime,
-		Environment:       req.Environment,
+		Environment:       environment,
 		SecretEnvironment: req.SecretEnvironment,
 		JobType:           jobType,
 		GPUCount:          req.GpuCount,
@@ -207,6 +211,30 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 	}
 
 	return jobRequest, nil
+}
+
+// reservedEnvKeys are environment variables the joblet runtime sets and the
+// isolation layer trusts; clients must not be able to supply them through a
+// job request.
+var reservedEnvKeys = map[string]bool{
+	"JOB_TYPE": true,
+}
+
+// sanitizeClientEnvironment returns a copy of the client-supplied environment
+// with reserved control variables removed. A nil or empty input is returned
+// unchanged.
+func sanitizeClientEnvironment(env map[string]string) map[string]string {
+	if len(env) == 0 {
+		return env
+	}
+	sanitized := make(map[string]string, len(env))
+	for k, v := range env {
+		if reservedEnvKeys[k] {
+			continue
+		}
+		sanitized[k] = v
+	}
+	return sanitized
 }
 
 func (s *JobServiceServer) validateJobRequest(req *interfaces.StartJobRequest) error {

--- a/internal/joblet/server/job_service_test.go
+++ b/internal/joblet/server/job_service_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"testing"
+
+	pb "github.com/ehsaniara/joblet-proto/v2/gen"
+	"github.com/ehsaniara/joblet/internal/joblet/domain"
+	"github.com/ehsaniara/joblet/pkg/logger"
+)
+
+// TestConvertToJobRequest_IgnoresClientJobTypeEnv is a regression test for
+// the runtime-build privilege-escalation bug (issue #258). The server must
+// never derive the JobType from client-supplied environment variables;
+// RunJob always produces standard-isolation jobs.
+func TestConvertToJobRequest_IgnoresClientJobTypeEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+	}{
+		{"runtime-build", map[string]string{"JOB_TYPE": "runtime-build"}},
+		{"mixed case", map[string]string{"JOB_TYPE": "Runtime-Build"}},
+		{"runtime-build with siblings", map[string]string{"JOB_TYPE": "runtime-build", "FOO": "bar"}},
+		{"empty env", map[string]string{}},
+		{"nil env", nil},
+	}
+
+	s := &JobServiceServer{logger: logger.New().WithField("test", "true")}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &pb.RunJobRequest{
+				Command:     "/bin/true",
+				Environment: tc.env,
+			}
+
+			got, err := s.convertToJobRequest(req)
+			if err != nil {
+				t.Fatalf("convertToJobRequest returned error: %v", err)
+			}
+			if got.JobType != domain.JobTypeStandard {
+				t.Fatalf("JobType = %q; want %q (client must not influence isolation mode)",
+					got.JobType, domain.JobTypeStandard)
+			}
+		})
+	}
+}

--- a/internal/joblet/server/job_service_validation_test.go
+++ b/internal/joblet/server/job_service_validation_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// writeTestRuntime creates <base>/<name>/runtime.yml with the given content
 func writeTestRuntime(t *testing.T, basePath, name, yml string) {
 	t.Helper()
 	dir := filepath.Join(basePath, name)

--- a/internal/joblet/server/monitoring_service.go
+++ b/internal/joblet/server/monitoring_service.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/ehsaniara/joblet-proto/v2/gen"
+	auth2 "github.com/ehsaniara/joblet/internal/joblet/auth"
 	"github.com/ehsaniara/joblet/internal/joblet/monitoring"
 	"github.com/ehsaniara/joblet/internal/joblet/monitoring/domain"
 	"github.com/ehsaniara/joblet/pkg/config"
@@ -20,14 +21,16 @@ import (
 // MonitoringServiceServer implements the gRPC monitoring service
 type MonitoringServiceServer struct {
 	pb.UnimplementedMonitoringServiceServer
+	auth    auth2.GRPCAuthorization
 	monitor *monitoring.Service
 	config  *config.Config
 	logger  *logger.Logger
 }
 
 // NewMonitoringServiceServer creates a new monitoring service server
-func NewMonitoringServiceServer(monitor *monitoring.Service, cfg *config.Config) *MonitoringServiceServer {
+func NewMonitoringServiceServer(auth auth2.GRPCAuthorization, monitor *monitoring.Service, cfg *config.Config) *MonitoringServiceServer {
 	return &MonitoringServiceServer{
+		auth:    auth,
 		monitor: monitor,
 		config:  cfg,
 		logger:  logger.WithField("component", "monitoring-grpc"),
@@ -36,6 +39,10 @@ func NewMonitoringServiceServer(monitor *monitoring.Service, cfg *config.Config)
 
 // GetSystemStatus returns the current system status
 func (s *MonitoringServiceServer) GetSystemStatus(ctx context.Context, req *pb.EmptyRequest) (*pb.SystemStatusResponse, error) {
+	if err := s.auth.Authorized(ctx, auth2.GetMetricsOp); err != nil {
+		s.logger.Warn("authorization failed", "error", err)
+		return nil, err
+	}
 
 	systemStatus := s.monitor.GetSystemStatus()
 	if systemStatus == nil {
@@ -48,6 +55,11 @@ func (s *MonitoringServiceServer) GetSystemStatus(ctx context.Context, req *pb.E
 // StreamSystemMetrics streams system metrics at the specified interval
 func (s *MonitoringServiceServer) StreamSystemMetrics(req *pb.StreamMetricsRequest, stream pb.MonitoringService_StreamSystemMetricsServer) error {
 	s.logger.Debug("StreamSystemMetrics called", "interval", req.IntervalSeconds, "filters", req.MetricTypes)
+
+	if err := s.auth.Authorized(stream.Context(), auth2.GetMetricsOp); err != nil {
+		s.logger.Warn("authorization failed", "error", err)
+		return err
+	}
 
 	// Default to 5 seconds if not specified
 	interval := time.Duration(req.IntervalSeconds) * time.Second

--- a/internal/joblet/server/network_service.go
+++ b/internal/joblet/server/network_service.go
@@ -39,7 +39,7 @@ func (s *NetworkServiceServer) CreateNetwork(ctx context.Context, req *pb.Create
 
 	log.Debug("create network request received")
 
-	if err := s.auth.Authorized(ctx, auth2.RunJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth2.CreateNetworkOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (s *NetworkServiceServer) CreateNetwork(ctx context.Context, req *pb.Create
 func (s *NetworkServiceServer) ListNetworks(ctx context.Context, req *pb.EmptyRequest) (*pb.Networks, error) {
 	log := s.logger.WithField("operation", "ListNetworks")
 
-	if err := s.auth.Authorized(ctx, auth2.StreamJobsOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth2.ListNetworksOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (s *NetworkServiceServer) RemoveNetwork(ctx context.Context, req *pb.Remove
 
 	log.Debug("remove network request received")
 
-	if err := s.auth.Authorized(ctx, auth2.RunJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth2.RemoveNetworkOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}

--- a/internal/joblet/server/runtime_service.go
+++ b/internal/joblet/server/runtime_service.go
@@ -47,7 +47,7 @@ func (s *RuntimeServiceServer) ListRuntimes(ctx context.Context, req *pb.EmptyRe
 	log := s.logger.WithField("operation", "ListRuntimes")
 
 	// Authorization check
-	if err := s.auth.Authorized(ctx, auth.GetJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth.ListRuntimesOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (s *RuntimeServiceServer) GetRuntimeInfo(ctx context.Context, req *pb.GetRu
 	log := s.logger.WithFields("operation", "GetRuntimeInfo", "runtime", req.Runtime)
 
 	// Authorization check
-	if err := s.auth.Authorized(ctx, auth.GetJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth.GetRuntimeInfoOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (s *RuntimeServiceServer) TestRuntime(ctx context.Context, req *pb.TestRunt
 	log := s.logger.WithFields("operation", "TestRuntime", "runtime", req.Runtime)
 
 	// Authorization check
-	if err := s.auth.Authorized(ctx, auth.RunJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth.TestRuntimeOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (s *RuntimeServiceServer) RemoveRuntime(ctx context.Context, req *pb.Remove
 	log.Info("runtime removal request received")
 
 	// Authorization check
-	if err := s.auth.Authorized(ctx, auth.RunJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth.RemoveRuntimeOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -361,7 +361,7 @@ func (s *RuntimeServiceServer) BuildRuntime(req *pb.BuildRuntimeRequest, stream 
 	log := s.logger.WithField("operation", "BuildRuntime")
 
 	// Authorization check
-	if err := s.auth.Authorized(stream.Context(), auth.RunJobOp); err != nil {
+	if err := s.auth.Authorized(stream.Context(), auth.BuildRuntimeOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return err
 	}
@@ -430,7 +430,7 @@ func (s *RuntimeServiceServer) ValidateRuntimeYAML(ctx context.Context, req *pb.
 	log := s.logger.WithField("operation", "ValidateRuntimeYAML")
 
 	// Authorization check
-	if err := s.auth.Authorized(ctx, auth.GetJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth.ValidateRuntimeOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}

--- a/internal/joblet/server/volume_service.go
+++ b/internal/joblet/server/volume_service.go
@@ -40,7 +40,7 @@ func (s *VolumeServiceServer) CreateVolume(ctx context.Context, req *pb.CreateVo
 
 	log.Debug("create volume request received")
 
-	if err := s.auth.Authorized(ctx, auth2.RunJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth2.CreateVolumeOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (s *VolumeServiceServer) CreateVolume(ctx context.Context, req *pb.CreateVo
 func (s *VolumeServiceServer) ListVolumes(ctx context.Context, req *pb.EmptyRequest) (*pb.Volumes, error) {
 	log := s.logger.WithField("operation", "ListVolumes")
 
-	if err := s.auth.Authorized(ctx, auth2.StreamJobsOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth2.ListVolumesOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (s *VolumeServiceServer) RemoveVolume(ctx context.Context, req *pb.RemoveVo
 
 	log.Debug("remove volume request received")
 
-	if err := s.auth.Authorized(ctx, auth2.RunJobOp); err != nil {
+	if err := s.auth.Authorized(ctx, auth2.RemoveVolumeOp); err != nil {
 		log.Warn("authorization failed", "error", err)
 		return nil, err
 	}

--- a/internal/modes/isolation/isolation.go
+++ b/internal/modes/isolation/isolation.go
@@ -26,7 +26,10 @@ type Isolator struct {
 
 // NewIsolator creates a new isolator with the given platform
 func NewIsolator(p platform.Platform, logger *logger.Logger) *Isolator {
-	cfg, _, _ := config.LoadConfig()
+	// Runs inside the job init path: no server config exists in the job
+	// filesystem. The server forwarded its effective filesystem settings
+	// via JOB_FS_* env vars; defaults cover the rest.
+	cfg := config.InitConfig()
 
 	return &Isolator{
 		platform:   p,

--- a/internal/modes/jobexec/jobexec.go
+++ b/internal/modes/jobexec/jobexec.go
@@ -40,7 +40,7 @@ func NewJobExecutor(platform platform.Platform, logger *logger.Logger, cfg *conf
 	uploadManager := upload.NewManager(platform, logger)
 
 	// Create environment builder with the correct parameters
-	envBuilder := environment.NewBuilder(platform, uploadManager, logger)
+	envBuilder := environment.NewBuilder(platform, uploadManager, cfg, logger)
 
 	return &JobExecutor{
 		platform:      platform,
@@ -79,12 +79,10 @@ func (je *JobExecutor) ExecuteInInitMode() error {
 // Execute executes the job using consolidated environment handling
 func Execute(logger *logger.Logger) error {
 	p := platform.NewPlatform()
-	// Load configuration - this is needed for workspace directory
-	cfg, _, err := config.LoadConfig()
-	if err != nil {
-		return errors.WrapConfigError("joblet", "config", err)
-	}
-	executor := NewJobExecutor(p, logger, cfg)
+	// Runs inside the job filesystem: no server config exists here. The
+	// server forwarded its effective filesystem settings via JOB_FS_* env
+	// vars; everything else arrives via the other JOB_* variables.
+	executor := NewJobExecutor(p, logger, config.InitConfig())
 	return executor.ExecuteJob()
 }
 

--- a/internal/rnx/cli/help.go
+++ b/internal/rnx/cli/help.go
@@ -48,15 +48,15 @@ nodes:
       ... (full CA certificate content) ...
       -----END CERTIFICATE-----
   
-  viewer:
+  reader:
     address: "192.168.1.100:50051"
     cert: |
       -----BEGIN CERTIFICATE-----
-      ... (viewer certificate with read-only permissions) ...
+      ... (reader certificate with read-only permissions) ...
       -----END CERTIFICATE-----
     key: |
       -----BEGIN PRIVATE KEY-----
-      ... (viewer private key) ...
+      ... (reader private key) ...
       -----END PRIVATE KEY-----
     ca: |
       -----BEGIN CERTIFICATE-----
@@ -73,7 +73,7 @@ nodes:
 	fmt.Println()
 	fmt.Println("Usage examples:")
 	fmt.Println("  rnx job list                    # uses 'default' node")
-	fmt.Println("  rnx --node=viewer job list      # uses 'viewer' node (read-only)")
+	fmt.Println("  rnx --node=reader job list      # uses 'reader' node (read-only)")
 	fmt.Println("  rnx --node=production job list  # uses 'production' node")
 	fmt.Println("  rnx --config=my-rnx-config.yml job list  # uses custom config file")
 	fmt.Println()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -509,8 +509,18 @@ func LoadConfig() (*Config, string, error) {
 // Returns the path of the loaded file or "built-in defaults" if no file found.
 // Does not return error if no file is found - uses defaults instead.
 func loadFromFile(config *Config) (string, error) {
+	// An explicitly set JOBLET_CONFIG_PATH is authoritative: no fallback to
+	// system locations, and a missing file is an error rather than silently
+	// loading a different config. (The job init path never calls LoadConfig -
+	// it uses built-in defaults directly.)
+	if envPath := os.Getenv("JOBLET_CONFIG_PATH"); envPath != "" {
+		if _, err := os.Stat(envPath); os.IsNotExist(err) {
+			return "", fmt.Errorf("JOBLET_CONFIG_PATH is set but file does not exist: %s", envPath)
+		}
+		return readConfigFile(config, envPath)
+	}
+
 	configPaths := []string{
-		os.Getenv("JOBLET_CONFIG_PATH"),
 		"/opt/joblet/config/joblet-config.yml",
 		"./config/joblet-config.yml",
 		"./joblet-config.yml",
@@ -526,19 +536,48 @@ func loadFromFile(config *Config) (string, error) {
 			continue
 		}
 
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return "", fmt.Errorf("failed to read config file %s: %w", path, err)
-		}
-
-		if err := yaml.Unmarshal(data, config); err != nil {
-			return "", fmt.Errorf("failed to parse config file %s: %w", path, err)
-		}
-
-		return path, nil
+		return readConfigFile(config, path)
 	}
 
-	return "built-in defaults (no config file found)", nil
+	return BuiltInDefaultsPath, nil
+}
+
+// BuiltInDefaultsPath is the path value LoadConfig reports when no config
+// file was found anywhere. Server mode treats this as a fatal installation
+// error; init mode inside job containers tolerates it.
+const BuiltInDefaultsPath = "built-in defaults (no config file found)"
+
+// InitConfig returns the configuration for the job init process: built-in
+// defaults overridden by the effective values the server loaded at startup
+// and forwarded through the job environment (JOB_FS_*). Init never reads
+// config files - the server config does not exist inside the job filesystem
+// and embeds private keys that jobs must not see.
+func InitConfig() *Config {
+	cfg := DefaultConfig
+	if v := os.Getenv("JOB_FS_WORKSPACE_DIR"); v != "" {
+		cfg.Filesystem.WorkspaceDir = v
+	}
+	if v := os.Getenv("JOB_FS_BASE_DIR"); v != "" {
+		cfg.Filesystem.BaseDir = v
+	}
+	if v := os.Getenv("JOB_FS_TMP_DIR"); v != "" {
+		cfg.Filesystem.TmpDir = v
+	}
+	return &cfg
+}
+
+// readConfigFile reads and parses a single config file into config
+func readConfigFile(config *Config, path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read config file %s: %w", path, err)
+	}
+
+	if err := yaml.Unmarshal(data, config); err != nil {
+		return "", fmt.Errorf("failed to parse config file %s: %w", path, err)
+	}
+
+	return path, nil
 }
 
 // runtimeConfigWrapper is used to unmarshal runtime config which only has the runtime section.
@@ -551,12 +590,19 @@ type runtimeConfigWrapper struct {
 // Searches for runtime-config.yml in standard locations.
 // Returns empty string if no runtime config file is found (not an error - uses main config values).
 func loadRuntimeConfig(config *Config) (string, error) {
-	runtimePaths := []string{
-		os.Getenv("JOBLET_RUNTIME_CONFIG_PATH"),
-		"/opt/joblet/config/runtime-config.yml",
-		"./config/runtime-config.yml",
-		"./runtime-config.yml",
-		"/etc/joblet/runtime-config.yml",
+	// An explicitly set JOBLET_RUNTIME_CONFIG_PATH is authoritative: no
+	// fallback to system locations. Runtime config is optional, so a missing
+	// explicit path just means no runtime config.
+	var runtimePaths []string
+	if envPath := os.Getenv("JOBLET_RUNTIME_CONFIG_PATH"); envPath != "" {
+		runtimePaths = []string{envPath}
+	} else {
+		runtimePaths = []string{
+			"/opt/joblet/config/runtime-config.yml",
+			"./config/runtime-config.yml",
+			"./runtime-config.yml",
+			"/etc/joblet/runtime-config.yml",
+		}
 	}
 
 	for _, path := range runtimePaths {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -327,6 +327,18 @@ MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBALr6hQ7lhZhh3j1f
 func TestLoadConfig(t *testing.T) {
 	// Test environment variable overrides
 	t.Run("environment overrides", func(t *testing.T) {
+		// Isolate from any joblet installed on this host: point both config
+		// paths into an empty temp dir so /opt/joblet is never consulted
+		tmpDir := t.TempDir()
+		os.Setenv("JOBLET_RUNTIME_CONFIG_PATH", filepath.Join(tmpDir, "no-runtime-config.yml"))
+		defer os.Unsetenv("JOBLET_RUNTIME_CONFIG_PATH")
+		configPath := filepath.Join(tmpDir, "joblet-config.yml")
+		if err := os.WriteFile(configPath, []byte("version: \"3.0\"\n"), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+		os.Setenv("JOBLET_CONFIG_PATH", configPath)
+		defer os.Unsetenv("JOBLET_CONFIG_PATH")
+
 		// Set environment variables
 		os.Setenv("JOBLET_SERVER_ADDRESS", "192.168.1.100")
 		os.Setenv("JOBLET_MODE", "init")
@@ -616,6 +628,9 @@ logging:
 
 		os.Setenv("JOBLET_CONFIG_PATH", configPath)
 		defer os.Unsetenv("JOBLET_CONFIG_PATH")
+		// Isolate from a runtime-config.yml installed on this host
+		os.Setenv("JOBLET_RUNTIME_CONFIG_PATH", filepath.Join(tmpDir, "no-runtime-config.yml"))
+		defer os.Unsetenv("JOBLET_RUNTIME_CONFIG_PATH")
 
 		config, path, err := LoadConfig()
 		if err != nil {
@@ -867,5 +882,36 @@ nodes:
 			t.Logf("LoadClientConfig found a config unexpectedly - system may have configs in /etc or /opt")
 		}
 		// Error is expected when no config is found
+	})
+}
+
+func TestInitConfig(t *testing.T) {
+	t.Run("defaults when nothing forwarded", func(t *testing.T) {
+		cfg := InitConfig()
+		if cfg.Filesystem.WorkspaceDir != DefaultConfig.Filesystem.WorkspaceDir {
+			t.Errorf("expected default workspace dir, got %q", cfg.Filesystem.WorkspaceDir)
+		}
+	})
+
+	t.Run("server-forwarded values win", func(t *testing.T) {
+		os.Setenv("JOB_FS_WORKSPACE_DIR", "/custom-work")
+		os.Setenv("JOB_FS_BASE_DIR", "/custom-jobs")
+		os.Setenv("JOB_FS_TMP_DIR", "/custom-tmp/{JOB_ID}")
+		defer func() {
+			os.Unsetenv("JOB_FS_WORKSPACE_DIR")
+			os.Unsetenv("JOB_FS_BASE_DIR")
+			os.Unsetenv("JOB_FS_TMP_DIR")
+		}()
+
+		cfg := InitConfig()
+		if cfg.Filesystem.WorkspaceDir != "/custom-work" {
+			t.Errorf("expected forwarded workspace dir, got %q", cfg.Filesystem.WorkspaceDir)
+		}
+		if cfg.Filesystem.BaseDir != "/custom-jobs" {
+			t.Errorf("expected forwarded base dir, got %q", cfg.Filesystem.BaseDir)
+		}
+		if cfg.Filesystem.TmpDir != "/custom-tmp/{JOB_ID}" {
+			t.Errorf("expected forwarded tmp dir, got %q", cfg.Filesystem.TmpDir)
+		}
 	})
 }

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -39,6 +39,23 @@ else
     echo "📦 Using existing binaries from ./bin/..."
 fi
 
+# Verify binary architecture matches the target package architecture
+case "$ARCH" in
+    amd64) EXPECTED_ARCH="x86-64" ;;
+    arm64) EXPECTED_ARCH="aarch64" ;;
+    *) EXPECTED_ARCH="" ;;
+esac
+if [ -n "$EXPECTED_ARCH" ]; then
+    for bin in joblet rnx persist state; do
+        if ! file "./bin/$bin" | grep -q "$EXPECTED_ARCH"; then
+            echo "❌ ./bin/$bin is not $EXPECTED_ARCH but package arch is $ARCH"
+            echo "   Rebuild with: make all GOARCH=$ARCH"
+            exit 1
+        fi
+    done
+    echo "✅ Binary architecture verified: $EXPECTED_ARCH"
+fi
+
 # Clean and create build directory
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
@@ -118,6 +135,10 @@ chmod +x "$BUILD_DIR/usr/local/bin/certs_gen_with_secretsmanager.sh"
 cp ./scripts/common-install-functions.sh "$BUILD_DIR/opt/joblet/scripts/"
 chmod 644 "$BUILD_DIR/opt/joblet/scripts/common-install-functions.sh"
 
+# Copy uninstall script
+cp ./scripts/uninstall.sh "$BUILD_DIR/opt/joblet/scripts/"
+chmod 755 "$BUILD_DIR/opt/joblet/scripts/uninstall.sh"
+
 # Create control file
 cat > "$BUILD_DIR/DEBIAN/control" << EOF
 Package: $PACKAGE_NAME
@@ -176,6 +197,6 @@ dpkg-deb -c "$PACKAGE_FILE"
 echo
 echo "🚀 Installation methods:"
 echo "  Interactive:    sudo dpkg -i $PACKAGE_FILE"
-echo "  Pre-configured: JOBLET_SERVER_IP='your-ip' sudo -E dpkg -i $PACKAGE_FILE"
+echo "  Pre-configured: JOBLET_CERT_INTERNAL_IP='your-ip' sudo -E dpkg -i $PACKAGE_FILE"
 echo "  Automated:      DEBIAN_FRONTEND=noninteractive sudo dpkg -i $PACKAGE_FILE"
 echo "  Reconfigure:    sudo dpkg-reconfigure joblet"

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -287,6 +287,18 @@ if generate_and_embed_certificates; then
     chmod 600 /opt/joblet/config/joblet-config.yml 2>/dev/null || true
     # rnx-config.yml needs to be readable for client usage
     chmod 644 /opt/joblet/config/rnx-config.yml 2>/dev/null || true
+
+    # Set up ~/.rnx for the user who ran the install (sudo), so rnx
+    # works out of the box for them
+    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+        SUDO_USER_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+        if [ -n "$SUDO_USER_HOME" ] && [ -d "$SUDO_USER_HOME" ]; then
+            mkdir -p "$SUDO_USER_HOME/.rnx"
+            cp /opt/joblet/config/rnx-config.yml "$SUDO_USER_HOME/.rnx/rnx-config.yml"
+            chown -R "$SUDO_USER:" "$SUDO_USER_HOME/.rnx"
+            echo "  Client config installed to $SUDO_USER_HOME/.rnx/rnx-config.yml"
+        fi
+    fi
 fi
 
 # Setup network requirements
@@ -492,6 +504,6 @@ echo "  - Bridge network:   rnx job run --network=bridge <command>"
 echo "  - Isolated network: rnx job run --network=isolated <command>"
 echo "  - Custom networks:  rnx network create <name> --cidr=<cidr>"
 echo ""
-echo "  With custom IP:     JOBLET_SERVER_IP='your-ip' sudo -E yum localinstall -y $PACKAGE_FILE"
+echo "  With custom IP:     JOBLET_CERT_INTERNAL_IP='your-ip' sudo -E yum localinstall -y $PACKAGE_FILE"
 echo "  Verification:       rpm -V joblet"
 echo "  Service:            sudo systemctl start joblet && sudo systemctl enable joblet"

--- a/scripts/certs_gen_embedded.sh
+++ b/scripts/certs_gen_embedded.sh
@@ -184,14 +184,19 @@ openssl x509 -req -days 365 -in server.csr -CA ca-cert.pem -CAkey ca-key.pem \
 
 print_success "Server certificate generated"
 
-# Generate admin client certificate
-print_info "Generating admin client certificate..."
-openssl genrsa -out admin-client-key.pem 2048
-openssl req -new -key admin-client-key.pem -out admin-client.csr \
-    -subj "/C=US/ST=CA/L=Los Angeles/O=Joblet/OU=admin/CN=admin-client"
-openssl x509 -req -days 365 -in admin-client.csr -CA ca-cert.pem -CAkey ca-key.pem \
-    -CAcreateserial -out admin-client-cert.pem
-print_success "Admin client certificate generated"
+# Generate one client certificate per role. The certificate OU carries the
+# role: admin (full access), maintainer (provision infrastructure + run jobs),
+# developer (run jobs on existing infrastructure), reader (read-only).
+CLIENT_ROLES="admin maintainer developer reader"
+for ROLE in $CLIENT_ROLES; do
+    print_info "Generating $ROLE client certificate..."
+    openssl genrsa -out "$ROLE-client-key.pem" 2048
+    openssl req -new -key "$ROLE-client-key.pem" -out "$ROLE-client.csr" \
+        -subj "/C=US/ST=CA/L=Los Angeles/O=Joblet/OU=$ROLE/CN=$ROLE-client"
+    openssl x509 -req -days 365 -in "$ROLE-client.csr" -CA ca-cert.pem -CAkey ca-key.pem \
+        -CAcreateserial -out "$ROLE-client-cert.pem"
+    print_success "$ROLE client certificate generated"
+done
 
 # Function to read and indent certificate content for YAML
 read_cert_for_yaml() {
@@ -313,7 +318,9 @@ fi
 print_info "Updating client configuration with embedded certificates..."
 CLIENT_CONFIG="$CONFIG_DIR/rnx-config.yml"
 
-# Create client configuration with embedded certificates
+# Create client configuration with embedded certificates.
+# "default" uses the admin certificate; one node per role is added so
+# clients can select a role with: rnx --node <role> ...
 cat > "$CLIENT_CONFIG" << EOF
 version: "3.0"
 
@@ -329,7 +336,43 @@ $(read_cert_for_yaml admin-client-key.pem "      ")
 $(read_cert_for_yaml ca-cert.pem "      ")
 EOF
 
-print_success "Client configuration created with embedded certificates"
+for ROLE in $CLIENT_ROLES; do
+    cat >> "$CLIENT_CONFIG" << EOF
+  $ROLE:
+    address: "$SERVER_ADDRESS:50051"
+    nodeId: "$NODE_ID"
+    cert: |
+$(read_cert_for_yaml "$ROLE-client-cert.pem" "      ")
+    key: |
+$(read_cert_for_yaml "$ROLE-client-key.pem" "      ")
+    ca: |
+$(read_cert_for_yaml ca-cert.pem "      ")
+EOF
+done
+
+# One config file per role for distribution: each contains only that role's
+# credentials, so handing rnx-config-developer.yml to a developer does not
+# also hand over the admin key.
+for ROLE in $CLIENT_ROLES; do
+    ROLE_CONFIG="$CONFIG_DIR/rnx-config-$ROLE.yml"
+    cat > "$ROLE_CONFIG" << EOF
+version: "3.0"
+
+nodes:
+  default:
+    address: "$SERVER_ADDRESS:50051"
+    nodeId: "$NODE_ID"
+    cert: |
+$(read_cert_for_yaml "$ROLE-client-cert.pem" "      ")
+    key: |
+$(read_cert_for_yaml "$ROLE-client-key.pem" "      ")
+    ca: |
+$(read_cert_for_yaml ca-cert.pem "      ")
+EOF
+    chmod 600 "$ROLE_CONFIG" 2>/dev/null || true
+done
+
+print_success "Client configurations created with embedded certificates"
 
 # Verify all certificates
 print_info "Verifying all certificates..."
@@ -342,12 +385,14 @@ else
     CERT_ERRORS=$((CERT_ERRORS + 1))
 fi
 
-if openssl verify -CAfile ca-cert.pem admin-client-cert.pem > /dev/null 2>&1; then
-    print_success "Admin client certificate verified"
-else
-    print_error "Admin client certificate verification failed"
-    CERT_ERRORS=$((CERT_ERRORS + 1))
-fi
+for ROLE in $CLIENT_ROLES; do
+    if openssl verify -CAfile ca-cert.pem "$ROLE-client-cert.pem" > /dev/null 2>&1; then
+        print_success "$ROLE client certificate verified"
+    else
+        print_error "$ROLE client certificate verification failed"
+        CERT_ERRORS=$((CERT_ERRORS + 1))
+    fi
+done
 
 # Set secure permissions on config files
 print_info "Setting secure permissions on configuration files..."
@@ -365,9 +410,14 @@ fi
 echo
 print_info "📋 Configuration files updated:"
 echo "  🖥️  Server Config: $SERVER_CONFIG"
-echo "  📱 Client Config: $CLIENT_CONFIG"
+echo "  📱 Operator Client Config (all roles): $CLIENT_CONFIG"
+for ROLE in $CLIENT_ROLES; do
+    echo "  📱 $ROLE Client Config: $CONFIG_DIR/rnx-config-$ROLE.yml"
+done
 echo "  🔐 All certificates are now embedded in configuration files"
 echo "  🗑️  No separate certificate files needed"
+echo "  ⚠️  Distribute only the per-role config file each party needs;"
+echo "      the combined rnx-config.yml contains the admin key and stays on the server"
 echo
 
 print_info "🚀 Usage:"

--- a/scripts/certs_gen_with_secretsmanager.sh
+++ b/scripts/certs_gen_with_secretsmanager.sh
@@ -347,6 +347,17 @@ store_secret() {
     fi
 }
 
+# Secret names for a role's client certificate pair. The unsuffixed
+# client-cert/client-key names are the admin pair; they predate the
+# four-role model and are kept so existing deployments continue to work.
+client_cert_secret() {
+    if [ "$1" = "admin" ]; then echo "${SECRETS_PREFIX}/client-cert"; else echo "${SECRETS_PREFIX}/client-cert-$1"; fi
+}
+
+client_key_secret() {
+    if [ "$1" = "admin" ]; then echo "${SECRETS_PREFIX}/client-key"; else echo "${SECRETS_PREFIX}/client-key-$1"; fi
+}
+
 # Validate certificate is still valid
 validate_cert() {
     local cert_file="$1"
@@ -462,7 +473,8 @@ fi
 # ============================================================================
 
 CA_FROM_SM="false"
-CLIENT_FROM_SM="false"
+CLIENT_ROLES="admin maintainer developer reader"
+RETRIEVED_ROLES=""
 
 if [ "$SHOULD_USE_SM" = "true" ] && [ "$FORCE_REGENERATE" != "true" ]; then
     print_info "Checking AWS Secrets Manager for existing CA and client certificates..."
@@ -495,32 +507,33 @@ if [ "$SHOULD_USE_SM" = "true" ] && [ "$FORCE_REGENERATE" != "true" ]; then
         print_warning "CA certificates not found in Secrets Manager (looked for ${SECRETS_PREFIX}/ca-cert and ${SECRETS_PREFIX}/ca-key)"
     fi
 
-    # Try to retrieve client certificate from Secrets Manager
-    if secret_exists "${SECRETS_PREFIX}/client-cert" "$EC2_REGION" && \
-       secret_exists "${SECRETS_PREFIX}/client-key" "$EC2_REGION"; then
-        print_info "Found client certificates in Secrets Manager, retrieving..."
+    # Try to retrieve the client certificate of each role from Secrets Manager
+    for ROLE in $CLIENT_ROLES; do
+        CERT_SECRET=$(client_cert_secret "$ROLE")
+        KEY_SECRET=$(client_key_secret "$ROLE")
 
-        CLIENT_CERT=$(get_secret "${SECRETS_PREFIX}/client-cert" "$EC2_REGION")
-        CLIENT_KEY=$(get_secret "${SECRETS_PREFIX}/client-key" "$EC2_REGION")
+        if secret_exists "$CERT_SECRET" "$EC2_REGION" && secret_exists "$KEY_SECRET" "$EC2_REGION"; then
+            CLIENT_CERT=$(get_secret "$CERT_SECRET" "$EC2_REGION")
+            CLIENT_KEY=$(get_secret "$KEY_SECRET" "$EC2_REGION")
 
-        if [ -n "$CLIENT_CERT" ] && [ -n "$CLIENT_KEY" ]; then
-            echo "$CLIENT_CERT" > admin-client-cert.pem
-            echo "$CLIENT_KEY" > admin-client-key.pem
+            if [ -n "$CLIENT_CERT" ] && [ -n "$CLIENT_KEY" ]; then
+                echo "$CLIENT_CERT" > "${ROLE}-client-cert.pem"
+                echo "$CLIENT_KEY" > "${ROLE}-client-key.pem"
 
-            # Validate client certificate
-            if validate_cert admin-client-cert.pem; then
-                print_success "Retrieved valid client certificate from Secrets Manager"
-                CLIENT_FROM_SM="true"
+                if validate_cert "${ROLE}-client-cert.pem"; then
+                    print_success "Retrieved valid $ROLE client certificate from Secrets Manager"
+                    RETRIEVED_ROLES="$RETRIEVED_ROLES $ROLE"
+                else
+                    print_warning "$ROLE client certificate from Secrets Manager is expired or invalid"
+                    rm -f "${ROLE}-client-cert.pem" "${ROLE}-client-key.pem"
+                fi
             else
-                print_warning "Client certificate from Secrets Manager is expired or invalid"
-                rm -f admin-client-cert.pem admin-client-key.pem
+                print_warning "$ROLE client certificate content is empty from Secrets Manager"
             fi
         else
-            print_warning "Client certificate content is empty from Secrets Manager"
+            print_warning "$ROLE client certificate not found in Secrets Manager (looked for $CERT_SECRET and $KEY_SECRET)"
         fi
-    else
-        print_warning "Client certificates not found in Secrets Manager (looked for ${SECRETS_PREFIX}/client-cert and ${SECRETS_PREFIX}/client-key)"
-    fi
+    done
 fi
 
 # Generate CA if not retrieved from Secrets Manager
@@ -543,27 +556,29 @@ else
     print_info "Using existing CA certificate from Secrets Manager"
 fi
 
-# Generate client certificate if not retrieved from Secrets Manager
-if [ "$CLIENT_FROM_SM" != "true" ]; then
-    print_info "Generating new admin client certificate..."
-    openssl genrsa -out admin-client-key.pem 2048
-    openssl req -new -key admin-client-key.pem -out admin-client.csr \
-        -subj "/C=US/ST=CA/L=Los Angeles/O=Joblet/OU=admin/CN=admin-client"
-    openssl x509 -req -days 365 -in admin-client.csr -CA ca-cert.pem -CAkey ca-key.pem \
-        -CAcreateserial -out admin-client-cert.pem
-    print_success "Admin client certificate generated"
+# Generate client certificates for roles not retrieved from Secrets Manager
+for ROLE in $CLIENT_ROLES; do
+    case " $RETRIEVED_ROLES " in *" $ROLE "*)
+        print_info "Using existing $ROLE client certificate from Secrets Manager"
+        continue;;
+    esac
 
-    # Store in Secrets Manager if enabled
+    print_info "Generating new $ROLE client certificate..."
+    openssl genrsa -out "${ROLE}-client-key.pem" 2048
+    openssl req -new -key "${ROLE}-client-key.pem" -out "${ROLE}-client.csr" \
+        -subj "/C=US/ST=CA/L=Los Angeles/O=Joblet/OU=${ROLE}/CN=${ROLE}-client"
+    openssl x509 -req -days 365 -in "${ROLE}-client.csr" -CA ca-cert.pem -CAkey ca-key.pem \
+        -CAcreateserial -out "${ROLE}-client-cert.pem"
+    print_success "$ROLE client certificate generated"
+
     if [ "$SHOULD_USE_SM" = "true" ]; then
-        print_info "Storing client certificate in Secrets Manager..."
-        store_secret "${SECRETS_PREFIX}/client-cert" "$(cat admin-client-cert.pem)" "$EC2_REGION" \
-            "Joblet Admin Client Certificate - shared across all clients"
-        store_secret "${SECRETS_PREFIX}/client-key" "$(cat admin-client-key.pem)" "$EC2_REGION" \
-            "Joblet Admin Client Private Key - shared across all clients"
+        print_info "Storing $ROLE client certificate in Secrets Manager..."
+        store_secret "$(client_cert_secret "$ROLE")" "$(cat "${ROLE}-client-cert.pem")" "$EC2_REGION" \
+            "Joblet $ROLE client certificate - shared across all clients with this role"
+        store_secret "$(client_key_secret "$ROLE")" "$(cat "${ROLE}-client-key.pem")" "$EC2_REGION" \
+            "Joblet $ROLE client private key - shared across all clients with this role"
     fi
-else
-    print_info "Using existing client certificate from Secrets Manager"
-fi
+done
 
 # ============================================================================
 # Server Certificate Generation (Always Generated Per-Instance)
@@ -700,7 +715,8 @@ fi
 print_info "Updating client configuration with embedded certificates..."
 CLIENT_CONFIG="$CONFIG_DIR/rnx-config.yml"
 
-# Create client configuration with embedded certificates
+# The combined config is the operator's copy: it contains every role's
+# credentials, admin included, and must stay on the server.
 cat > "$CLIENT_CONFIG" << EOF
 version: "3.0"
 
@@ -716,7 +732,43 @@ $(read_cert_for_yaml admin-client-key.pem "      ")
 $(read_cert_for_yaml ca-cert.pem "      ")
 EOF
 
-print_success "Client configuration created with embedded certificates"
+for ROLE in $CLIENT_ROLES; do
+    cat >> "$CLIENT_CONFIG" << EOF
+  $ROLE:
+    address: "$SERVER_ADDRESS:50051"
+    nodeId: "$NODE_ID"
+    cert: |
+$(read_cert_for_yaml "$ROLE-client-cert.pem" "      ")
+    key: |
+$(read_cert_for_yaml "$ROLE-client-key.pem" "      ")
+    ca: |
+$(read_cert_for_yaml ca-cert.pem "      ")
+EOF
+done
+
+# One config file per role for distribution: each contains only that role's
+# credentials, so handing rnx-config-developer.yml to a developer does not
+# also hand over the admin key.
+for ROLE in $CLIENT_ROLES; do
+    ROLE_CONFIG="$CONFIG_DIR/rnx-config-$ROLE.yml"
+    cat > "$ROLE_CONFIG" << EOF
+version: "3.0"
+
+nodes:
+  default:
+    address: "$SERVER_ADDRESS:50051"
+    nodeId: "$NODE_ID"
+    cert: |
+$(read_cert_for_yaml "$ROLE-client-cert.pem" "      ")
+    key: |
+$(read_cert_for_yaml "$ROLE-client-key.pem" "      ")
+    ca: |
+$(read_cert_for_yaml ca-cert.pem "      ")
+EOF
+    chmod 600 "$ROLE_CONFIG" 2>/dev/null || true
+done
+
+print_success "Client configurations created with embedded certificates"
 
 # Verify all certificates
 print_info "Verifying all certificates..."
@@ -729,12 +781,14 @@ else
     CERT_ERRORS=$((CERT_ERRORS + 1))
 fi
 
-if openssl verify -CAfile ca-cert.pem admin-client-cert.pem > /dev/null 2>&1; then
-    print_success "Admin client certificate verified"
-else
-    print_error "Admin client certificate verification failed"
-    CERT_ERRORS=$((CERT_ERRORS + 1))
-fi
+for ROLE in $CLIENT_ROLES; do
+    if openssl verify -CAfile ca-cert.pem "$ROLE-client-cert.pem" > /dev/null 2>&1; then
+        print_success "$ROLE client certificate verified"
+    else
+        print_error "$ROLE client certificate verification failed"
+        CERT_ERRORS=$((CERT_ERRORS + 1))
+    fi
+done
 
 # Set secure permissions on config files
 print_info "Setting secure permissions on configuration files..."
@@ -752,8 +806,13 @@ fi
 echo
 print_info "📋 Configuration files updated:"
 echo "  🖥️  Server Config: $SERVER_CONFIG"
-echo "  📱 Client Config: $CLIENT_CONFIG"
+echo "  📱 Operator Client Config (all roles): $CLIENT_CONFIG"
+for ROLE in $CLIENT_ROLES; do
+    echo "  📱 $ROLE Client Config: $CONFIG_DIR/rnx-config-$ROLE.yml"
+done
 echo "  🔐 All certificates are now embedded in configuration files"
+echo "  ⚠️  Distribute only the per-role config file each party needs;"
+echo "      the combined rnx-config.yml contains the admin key and stays on the server"
 if [ "$SHOULD_USE_SM" = "true" ]; then
     echo ""
     print_info "🔑 AWS Secrets Manager Integration:"
@@ -762,16 +821,17 @@ if [ "$SHOULD_USE_SM" = "true" ]; then
     else
         echo "  ✨ CA Certificate: Generated and stored in Secrets Manager (shared)"
     fi
-    if [ "$CLIENT_FROM_SM" = "true" ]; then
-        echo "  ✅ Client Certificate: Retrieved from Secrets Manager (shared)"
-    else
-        echo "  ✨ Client Certificate: Generated and stored in Secrets Manager (shared)"
-    fi
+    for ROLE in $CLIENT_ROLES; do
+        case " $RETRIEVED_ROLES " in
+            *" $ROLE "*) echo "  ✅ $ROLE Client Certificate: Retrieved from Secrets Manager (shared)";;
+            *) echo "  ✨ $ROLE Client Certificate: Generated and stored in Secrets Manager (shared)";;
+        esac
+    done
     echo "  🆕 Server Certificate: Generated locally (instance-specific)"
     echo ""
     print_info "📊 Scaling Benefits:"
     echo "  • Additional instances will reuse the same CA and client certificates"
-    echo "  • Clients only need one config file to connect to all instances"
+    echo "  • Grant each client's IAM principal access to only its role's secrets"
     echo "  • Each server gets its own certificate for security"
 fi
 echo

--- a/scripts/joblet.service
+++ b/scripts/joblet.service
@@ -33,8 +33,7 @@ RestrictSUIDSGID=no
 MemoryDenyWriteExecute=no
 
 # Cgroup delegation for job resource management
-Delegate=yes
-DelegateControllers=cpu memory io pids
+Delegate=cpu memory io pids
 CPUAccounting=yes
 MemoryAccounting=yes
 IOAccounting=yes
@@ -53,7 +52,7 @@ Environment="LOG_LEVEL=INFO"
 Environment="JOBLET_CONFIG_PATH=/opt/joblet/config/joblet-config.yml"
 
 # Cleanup job cgroups on service stop
-ExecStopPost=/bin/bash -c 'find /sys/fs/cgroup/joblet.slice/joblet.service -name "job-*" -type d -exec rmdir {} \; 2>/dev/null || true'
+ExecStopPost=/bin/bash -c 'find /sys/fs/cgroup/joblet.slice/joblet.service -name "job-*" -type d -exec rmdir {} + 2>/dev/null || true'
 
 # Note: Log files in ${JOBLET_HOME}/logs are preserved across service restarts
 # Use 'rnx logs cleanup' or manual cleanup if needed

--- a/scripts/pre-pr-check.sh
+++ b/scripts/pre-pr-check.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Pre-PR verification pipeline
+#
+# Run this before opening a PR. It validates the working tree end to end on
+# this machine's architecture:
+#
+#   1. Run unit tests (make test)
+#   2. Build and deploy the local changes to the joblet service (make deploy)
+#   3. Run the e2e suite against the deployed service
+#   4. Uninstall joblet completely (--purge)
+#   5. Build a .deb from the working tree and install it, verifying the
+#      package pipeline works on this host's architecture and OS
+#   6. Smoke-test the packaged install (service up, rnx runs a job)
+#
+# Must run in a real terminal - several steps use sudo.
+#
+# Environment:
+#   E2E_EXCLUDE   Suites to skip, comma-separated patterns.
+#                 Default: "02_,09_" (runtime suite needs runtimes built,
+#                 GPU suite needs GPU hardware). Set E2E_EXCLUDE="" to run all.
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ARCH=$(go env GOARCH)
+E2E_EXCLUDE="${E2E_EXCLUDE-02_,09_}"
+
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+step() {
+    echo -e "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}  $1${NC}"
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+}
+
+fail() {
+    echo -e "\n${RED}❌ PRE-PR CHECK FAILED: $1${NC}"
+    exit 1
+}
+
+if [ ! -t 0 ]; then
+    echo "⚠️  No terminal detected - sudo prompts will fail. Run this in a real terminal."
+fi
+
+step "1/6 Unit tests"
+make -C "$ROOT" test || fail "unit tests"
+
+step "2/6 Deploy local changes ($ARCH)"
+make -C "$ROOT" deploy || fail "deploy"
+
+step "3/6 Run e2e suite"
+if [ -n "$E2E_EXCLUDE" ]; then
+    echo -e "${BLUE}Excluding suites: $E2E_EXCLUDE (set E2E_EXCLUDE=\"\" to run all)${NC}"
+    SKIP_DEPLOY=1 "$ROOT/tests/e2e/run_tests.sh" -x "$E2E_EXCLUDE" || fail "e2e suite"
+else
+    SKIP_DEPLOY=1 "$ROOT/tests/e2e/run_tests.sh" || fail "e2e suite"
+fi
+
+step "4/6 Uninstall joblet (purge)"
+sudo "$ROOT/scripts/uninstall.sh" --purge || fail "uninstall"
+
+step "5/6 Build and install local .deb ($ARCH)"
+VERSION=$(cd "$ROOT" && git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-dev")
+(cd "$ROOT" && ./scripts/build-deb.sh "$ARCH" "$VERSION") || fail "package build"
+DEB=$(ls -t "$ROOT"/joblet_*_"$ARCH".deb | head -1)
+echo -e "${BLUE}Installing: $DEB${NC}"
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i "$DEB" || fail "package install"
+sudo systemctl start joblet.service || fail "service start"
+
+step "6/6 Smoke test packaged install"
+echo -e "${BLUE}Waiting for service readiness (persist socket + gRPC)...${NC}"
+ready=0
+for i in $(seq 1 30); do
+    if [ -S /opt/joblet/run/persist-ipc.sock ] && rnx job list >/dev/null 2>&1; then
+        ready=1
+        break
+    fi
+    sleep 0.5
+done
+[ "$ready" -eq 1 ] || fail "service not ready after 15s - check: journalctl -u joblet"
+systemctl is-active --quiet joblet.service || fail "service not active"
+echo -e "${GREEN}✓ Service active and ready${NC}"
+
+[ -f "$HOME/.rnx/rnx-config.yml" ] || fail "~/.rnx/rnx-config.yml not created by installer"
+echo -e "${GREEN}✓ ~/.rnx client config installed${NC}"
+
+JOB_ID=$(rnx job run echo "pre-pr smoke test" 2>&1 | grep '^ID:' | awk '{print $2}')
+[ -n "$JOB_ID" ] || fail "could not submit smoke-test job"
+# On a fresh install the IPC writer's first persist connection can take a few
+# seconds (5s retry interval); buffered logs land right after it connects
+logs_ok=0
+for i in $(seq 1 10); do
+    if rnx job log "$JOB_ID" 2>/dev/null | grep -q "pre-pr smoke test"; then
+        logs_ok=1
+        break
+    fi
+    sleep 2
+done
+[ "$logs_ok" -eq 1 ] || fail "smoke-test job produced no output after 20s"
+echo -e "${GREEN}✓ Job execution works (job $JOB_ID)${NC}"
+
+echo -e "\n${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}  ✅ PRE-PR CHECK PASSED${NC}"
+echo -e "${GREEN}  Deploy + e2e + clean packaged install verified on $(uname -m)/$(. /etc/os-release && echo "$ID $VERSION_ID")${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+# Joblet Uninstall Script
+# Removes all joblet components from this host: service, binaries, configs,
+# data, network resources, symlinks, and per-user rnx client configs.
+#
+# Usage:
+#   sudo ./uninstall.sh              # Uninstall, keep job logs/volumes
+#   sudo ./uninstall.sh --purge      # Uninstall and remove ALL data
+#   sudo ./uninstall.sh --purge --all-users   # Also remove every user's ~/.rnx
+
+set -e
+
+JOBLET_HOME="${JOBLET_HOME:-/opt/joblet}"
+
+PURGE=false
+ALL_USERS=false
+for arg in "$@"; do
+    case "$arg" in
+        --purge) PURGE=true ;;
+        --all-users) ALL_USERS=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \?//' | head -10
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg (use --purge, --all-users, or --help)"
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "❌ This script must be run as root (sudo $0)"
+    exit 1
+fi
+
+echo "🗑️  Uninstalling joblet..."
+
+# ============================================
+# Stop and remove the service
+# ============================================
+if systemctl list-unit-files joblet.service >/dev/null 2>&1; then
+    systemctl stop joblet.service 2>/dev/null || true
+    systemctl disable joblet.service 2>/dev/null || true
+fi
+
+# ============================================
+# Clean up network resources
+# ============================================
+echo "  Cleaning up network resources..."
+
+# Remove NAT rules
+iptables -t nat -D POSTROUTING -s 172.20.0.0/16 -j MASQUERADE 2>/dev/null || true
+iptables-save 2>/dev/null | grep "POSTROUTING.*10\.255\.255\.2.*MASQUERADE" | \
+    sed 's/-A/-D/' | while read -r rule; do
+    iptables -t nat $rule 2>/dev/null || true
+done
+
+# Remove FORWARD rules
+iptables -S FORWARD 2>/dev/null | grep -E "joblet|viso" | sed 's/^-A/-D/' | while read -r rule; do
+    iptables $rule 2>/dev/null || true
+done
+
+# Remove veth interfaces and bridges
+for veth in $(ip link show 2>/dev/null | grep -o 'viso[0-9]*' | grep -v '@'); do
+    ip link delete "$veth" 2>/dev/null || true
+done
+for bridge in $(ip link show type bridge 2>/dev/null | grep -o 'joblet[^ :]*'); do
+    ip link delete "$bridge" 2>/dev/null || true
+done
+
+# ============================================
+# Clean up cgroups
+# ============================================
+if [ -d "/sys/fs/cgroup/joblet.slice" ]; then
+    find /sys/fs/cgroup/joblet.slice -name "job-*" -type d -exec rmdir {} \; 2>/dev/null || true
+fi
+
+# ============================================
+# Remove the package registration (deb/rpm installs)
+# ============================================
+if command -v dpkg >/dev/null 2>&1 && dpkg -s joblet >/dev/null 2>&1; then
+    echo "  Removing dpkg package..."
+    if [ "$PURGE" = true ]; then
+        dpkg --purge joblet 2>/dev/null || true
+    else
+        dpkg --remove joblet 2>/dev/null || true
+    fi
+elif command -v rpm >/dev/null 2>&1 && rpm -q joblet >/dev/null 2>&1; then
+    echo "  Removing rpm package..."
+    rpm -e joblet 2>/dev/null || true
+fi
+
+# ============================================
+# Remove files, symlinks, and service unit
+# ============================================
+echo "  Removing binaries, symlinks, and service unit..."
+rm -f /etc/systemd/system/joblet.service
+rm -f /usr/bin/joblet /usr/bin/rnx
+rm -f /usr/local/bin/joblet /usr/local/bin/rnx
+rm -f /usr/local/bin/certs_gen_embedded.sh /usr/local/bin/certs_gen_with_secretsmanager.sh
+rm -rf /etc/joblet
+systemctl daemon-reload 2>/dev/null || true
+
+# ============================================
+# Remove installation directory and data
+# ============================================
+if [ "$PURGE" = true ]; then
+    echo "  Removing all joblet data..."
+    rm -rf "${JOBLET_HOME}"
+    rm -rf /var/log/joblet /var/lib/joblet
+else
+    # Keep job logs and volumes unless purging
+    rm -rf "${JOBLET_HOME}/bin" "${JOBLET_HOME}/config" "${JOBLET_HOME}/scripts" "${JOBLET_HOME}/run"
+    rm -rf /var/log/joblet
+    if [ -d "${JOBLET_HOME}" ] && [ -n "$(ls -A "${JOBLET_HOME}" 2>/dev/null)" ]; then
+        echo "  Note: data preserved in ${JOBLET_HOME} (logs, volumes, runtimes)"
+        echo "        run with --purge to remove everything"
+    else
+        rm -rf "${JOBLET_HOME}"
+    fi
+fi
+
+# ============================================
+# Remove per-user rnx client configs (~/.rnx)
+# ============================================
+remove_user_rnx() {
+    local home="$1"
+    if [ -n "$home" ] && [ -d "$home/.rnx" ]; then
+        rm -rf "$home/.rnx"
+        echo "  Removed $home/.rnx"
+    fi
+}
+
+if [ "$ALL_USERS" = true ]; then
+    remove_user_rnx /root
+    for home in /home/*; do
+        [ -d "$home" ] && remove_user_rnx "$home"
+    done
+else
+    # Remove for root and the user who invoked sudo
+    remove_user_rnx /root
+    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+        remove_user_rnx "$(getent passwd "$SUDO_USER" | cut -d: -f6)"
+    fi
+    # Warn about other users that still have client configs
+    for home in /home/*; do
+        [ -d "$home/.rnx" ] && echo "  Note: $home/.rnx left in place (use --all-users to remove)"
+    done
+fi
+
+# ============================================
+# Clean up systemd journal entries
+# ============================================
+echo "  Cleaning up journal logs..."
+# Remove a dedicated joblet journal namespace if one exists
+systemctl stop systemd-journald@joblet.service 2>/dev/null || true
+rm -rf /var/log/journal/*.joblet /run/log/journal/*.joblet 2>/dev/null || true
+# Entries in the shared system journal cannot be deleted per-unit; rotate so
+# they land in archive files and expire with the normal journald retention
+journalctl --rotate 2>/dev/null || true
+if [ "$PURGE" = true ]; then
+    echo "  Note: joblet entries in the shared system journal expire with journald"
+    echo "        retention; deleting them now would wipe other services' logs too"
+fi
+
+# ============================================
+# Remove the joblet system user
+# ============================================
+if id joblet >/dev/null 2>&1; then
+    userdel joblet 2>/dev/null || true
+fi
+
+echo "✅ Joblet uninstalled"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -17,7 +17,7 @@ team-configurable parameters.
 ./run_tests.sh -t volume       # Volume management tests
 
 # ⚡ Development/debugging (skip build - use cautiously)
-./run_tests.sh --no-build      # Skip build for rapid test iteration
+SKIP_DEPLOY=1 ./run_tests.sh   # Skip build/deploy for rapid test iteration
 
 # 📋 List available tests
 ./run_tests.sh --list
@@ -37,10 +37,10 @@ Tests can run **locally** (default) or against a **remote joblet instance**:
 ./run_tests.sh
 
 # Remote testing - Useful for integration testing across machines
-JOBLET_TEST_HOST=192.168.1.161 ./run_tests.sh
+JOBLET_TEST_HOST=192.0.2.10 ./run_tests.sh
 
 # Run specific test remotely
-JOBLET_TEST_HOST=192.168.1.161 ./tests/11_metrics_gap_test.sh
+JOBLET_TEST_HOST=192.0.2.10 ./tests/11_metrics_gap_test.sh
 ```
 
 **Environment Variables**:

--- a/tests/e2e/lib/test_framework.sh
+++ b/tests/e2e/lib/test_framework.sh
@@ -343,6 +343,39 @@ cleanup_test_artifacts() {
     # Note: Add job cleanup logic here if needed
 }
 
+# Remove all state left behind by previous test runs so suites start clean:
+# jobs (stopped/canceled then deleted), test-* networks, test-* volumes, temp files
+cleanup_previous_test_state() {
+    echo -e "${YELLOW}▶ Cleaning up state from previous test runs${NC}"
+
+    local jobs
+    jobs=$("$RNX_BINARY" job list 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')
+
+    # Cancel scheduled and stop running jobs so delete-all can remove everything
+    echo "$jobs" | awk '$3 == "SCHEDULED" {print $1}' | while read -r id; do
+        "$RNX_BINARY" job cancel "$id" >/dev/null 2>&1 || true
+    done
+    echo "$jobs" | awk '$3 == "RUNNING" || $3 == "INITIALIZING" {print $1}' | while read -r id; do
+        "$RNX_BINARY" job stop "$id" >/dev/null 2>&1 || true
+    done
+
+    local job_count
+    job_count=$(echo "$jobs" | grep -cE '^[0-9a-f]{8}-' || true)
+    "$RNX_BINARY" job delete-all >/dev/null 2>&1 || true
+
+    # Remove leftover test networks and volumes (test-* naming convention)
+    "$RNX_BINARY" network list 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | awk '{print $1}' | grep '^test-' | while read -r net; do
+        "$RNX_BINARY" network remove "$net" >/dev/null 2>&1 || true
+    done
+    "$RNX_BINARY" volume list 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | awk '{print $1}' | grep '^test-' | while read -r vol; do
+        "$RNX_BINARY" volume remove "$vol" >/dev/null 2>&1 || true
+    done
+
+    rm -f /tmp/test_*.txt /tmp/test_*.yaml /tmp/test_*.log 2>/dev/null || true
+
+    echo -e "  ${GREEN}✓ Previous test state cleaned (removed $job_count leftover jobs)${NC}\n"
+}
+
 # ============================================
 # Remote Execution Helpers
 # ============================================
@@ -373,8 +406,10 @@ run_rnx_command() {
         ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no \
             "$JOBLET_TEST_USER@$JOBLET_TEST_HOST" "rnx $rnx_args" 2>&1 || true
     else
-        # Local RNX
-        "$RNX_BINARY" $rnx_args 2>&1 || true
+        # Local RNX - eval so quoted arguments are parsed the same way the
+        # remote shell parses them (plain $rnx_args would split on spaces and
+        # pass quote characters through literally)
+        eval '"$RNX_BINARY"' "$rnx_args" 2>&1 || true
     fi
 }
 
@@ -392,5 +427,5 @@ export -f test_suite_init test_section run_test skip_test
 export -f assert_equals assert_contains assert_numeric_le assert_file_exists
 export -f run_job run_python_job get_job_logs get_clean_output check_job_status
 export -f runtime_exists ensure_runtime get_runtime_info get_runtime_example_dir
-export -f test_suite_summary check_prerequisites cleanup_test_artifacts
+export -f test_suite_summary check_prerequisites cleanup_test_artifacts cleanup_previous_test_state
 export -f run_remote_command run_rnx_command get_test_host_display

--- a/tests/e2e/run_tests.sh
+++ b/tests/e2e/run_tests.sh
@@ -147,6 +147,7 @@ OPTIONS:
     -h, --help          Show this help message
     -v, --verbose       Enable verbose output
     -t, --test PATTERN  Run only tests matching pattern
+    -x, --exclude PAT   Skip tests matching pattern (comma-separated, e.g. "02_,09_")
     -l, --list          List available tests without running
 
 EXAMPLES:
@@ -188,6 +189,7 @@ list_tests() {
 
 main() {
     local test_pattern=""
+    local exclude_patterns=""
     local list_only=false
     
     # Parse command line arguments
@@ -203,6 +205,10 @@ main() {
                 ;;
             -t|--test)
                 test_pattern="$2"
+                shift 2
+                ;;
+            -x|--exclude)
+                exclude_patterns="$2"
                 shift 2
                 ;;
             -l|--list)
@@ -230,6 +236,24 @@ main() {
         TESTS_TO_RUN=("${filtered[@]}")
     fi
     
+    # Apply exclusion patterns
+    if [[ -n "$exclude_patterns" ]]; then
+        local kept=()
+        for test in "${TESTS_TO_RUN[@]}"; do
+            local excluded=false
+            IFS=',' read -ra patterns <<< "$exclude_patterns"
+            for pat in "${patterns[@]}"; do
+                if [[ "$(basename "$test")" == *"$pat"* ]]; then
+                    excluded=true
+                    echo -e "${YELLOW}⊘ Excluding: $(basename "$test" .sh) (matched '$pat')${NC}"
+                    break
+                fi
+            done
+            [[ "$excluded" == "false" ]] && kept+=("$test")
+        done
+        TESTS_TO_RUN=("${kept[@]}")
+    fi
+
     # List tests if requested
     if [[ "$list_only" == "true" ]]; then
         list_tests
@@ -248,7 +272,10 @@ main() {
     else
         echo -e "${YELLOW}⊘ Skipping build and deploy (SKIP_DEPLOY=1)${NC}\n"
     fi
-    
+
+    # Start from a clean slate: remove jobs/networks/volumes left by prior runs
+    cleanup_previous_test_state
+
     # Run tests
     run_all_tests
     exit $?

--- a/tests/e2e/tests/01_isolation_test.sh
+++ b/tests/e2e/tests/01_isolation_test.sh
@@ -1,31 +1,28 @@
 #!/bin/bash
 
 # Core Isolation Tests - Testing Joblet's Main Principles
-# Tests against remote host at 192.168.1.161
+# Runs against the local joblet by default; set JOBLET_TEST_HOST for a remote instance
 # Verifies: 2-stage execution, namespace isolation, init process, cgroups, filesystem isolation
 
 # Source the test framework
 source "$(dirname "$0")/../lib/test_framework.sh"
 
-# Remote host configuration
-REMOTE_HOST="192.168.1.161"
-REMOTE_USER="jay"
+TEST_HOST="$(get_test_host_display)"
 
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${CYAN}  Joblet Core Isolation Tests${NC}"
-echo -e "${CYAN}  Testing against remote host: ${REMOTE_HOST}${NC}"
+echo -e "${CYAN}  Testing against: ${TEST_HOST}${NC}"
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${BLUE}Started: $(date '+%Y-%m-%d %H:%M:%S')${NC}\n"
 
-# Verify we're connected to remote host
-echo -e "${YELLOW}▶ Verifying Remote Connection${NC}"
+# Verify we can reach the joblet service
+echo -e "${YELLOW}▶ Verifying Joblet Connection${NC}"
 echo -e "${BLUE}─────────────────────────────────────────────────────────────────${NC}\n"
 
-# Check RNX configuration points to remote host
-if grep -q "$REMOTE_HOST" ~/.rnx/rnx-config.yml 2>/dev/null; then
-    echo -e "  ${GREEN}✓ RNX configured for remote host $REMOTE_HOST${NC}"
+if check_prerequisites; then
+    echo -e "  ${GREEN}✓ Connected to joblet on $TEST_HOST${NC}"
 else
-    echo -e "  ${RED}✗ RNX not configured for remote host${NC}"
+    echo -e "  ${RED}✗ Cannot connect to joblet on $TEST_HOST${NC}"
     exit 1
 fi
 
@@ -475,14 +472,16 @@ echo -e "\n${YELLOW}▶ 8. UTS Namespace Isolation${NC}"
 echo -e "${BLUE}─────────────────────────────────────────────────────────────────${NC}"
 
 test_uts_namespace() {
-    local output=$(run_remote_job "hostname")
-    
-    # In isolated UTS namespace, hostname should be different from host
-    if [[ -n "$output" ]] && [[ "$output" != "$REMOTE_HOST" ]]; then
-        echo "    Hostname isolated: $output"
+    # Joblet unshares UTS but keeps the inherited hostname, so compare
+    # namespace identity rather than hostname strings
+    local job_ns=$(run_remote_job "readlink /proc/self/ns/uts")
+    local host_ns=$(run_remote_command "readlink /proc/self/ns/uts")
+
+    if [[ -n "$job_ns" ]] && [[ -n "$host_ns" ]] && [[ "$job_ns" != "$host_ns" ]]; then
+        echo "    UTS namespace isolated (job: $job_ns, host: $host_ns)"
         return 0
     fi
-    echo "    UTS namespace may not be isolated"
+    echo "    UTS namespace may not be isolated (job: $job_ns, host: $host_ns)"
     return 1
 }
 
@@ -495,7 +494,7 @@ run_test_check "UTS namespace isolation" test_uts_namespace
 echo -e "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${CYAN}  Test Summary${NC}"
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "Remote Host:    ${BLUE}$REMOTE_HOST${NC}"
+echo -e "Test Host:      ${BLUE}$TEST_HOST${NC}"
 echo -e "Total Tests:    $TOTAL_TESTS"
 echo -e "Passed:         ${GREEN}$PASSED_TESTS${NC}"
 echo -e "Failed:         ${RED}$FAILED_TESTS${NC}"
@@ -509,7 +508,7 @@ echo -e "\n${BLUE}Completed: $(date '+%Y-%m-%d %H:%M:%S')${NC}"
 
 if [[ $FAILED_TESTS -eq 0 ]]; then
     echo -e "\n${GREEN}✅ ALL CORE ISOLATION TESTS PASSED!${NC}"
-    echo -e "${GREEN}Joblet isolation is working correctly on $REMOTE_HOST${NC}"
+    echo -e "${GREEN}Joblet isolation is working correctly on $TEST_HOST${NC}"
     exit 0
 else
     echo -e "\n${RED}❌ SOME CORE ISOLATION TESTS FAILED${NC}"

--- a/tests/e2e/tests/02_runtime_test.sh
+++ b/tests/e2e/tests/02_runtime_test.sh
@@ -13,12 +13,11 @@ JOBLET_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 
 # Runtimes that will be tested (these have example runtime.yaml files)
 AVAILABLE_RUNTIMES=("openjdk-21" "openjdk-17" "python-3.11-ml" "python-3.11" "python-analytics")
-REMOTE_HOST="192.168.1.161"
-REMOTE_USER="jay"
+TEST_HOST="$(get_test_host_display)"
 
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${CYAN}  Complete Runtime Lifecycle Tests${NC}"
-echo -e "${CYAN}  Testing against remote host: ${REMOTE_HOST}${NC}"
+echo -e "${CYAN}  Testing against: ${TEST_HOST}${NC}"
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${BLUE}Started: $(date '+%Y-%m-%d %H:%M:%S')${NC}\n"
 
@@ -49,15 +48,15 @@ run_test_check() {
 # ============================================
 
 check_host_contamination() {
-    echo "  Checking for host contamination on $REMOTE_HOST..."
+    echo "  Checking for host contamination on $TEST_HOST..."
     
     # Check for joblet-specific runtime installations outside /opt/joblet
     # Look for newly installed runtimes, not system Python/Java
-    local contamination_check=$(ssh "$REMOTE_USER@$REMOTE_HOST" "
+    local contamination_check=$(run_remote_command "
         # Check for joblet-installed runtimes in unexpected locations
         find /usr/local -name '*graalvm*' -o -name '*openjdk-21*' 2>/dev/null | grep -v /opt/joblet
         find /usr/local -path '*/python3.11*' -newer /tmp 2>/dev/null | grep -v /opt/joblet
-    " 2>/dev/null)
+    " 30)
     
     if [[ -z "$contamination_check" ]]; then
         echo "    Host system clean - no joblet runtime contamination"
@@ -198,19 +197,13 @@ test_runtime_execution() {
 test_initial_state() {
     echo "  Checking initial runtime state..."
     
-    # Verify we're connected to remote host
-    if ! grep -q "$REMOTE_HOST" ~/.rnx/rnx-config.yml 2>/dev/null; then
-        echo "    Not connected to remote host $REMOTE_HOST"
-        return 1
-    fi
-    
-    # Check runtime list command works
+    # Check runtime list command works (verifies connectivity)
     if ! "$RNX_BINARY" runtime list >/dev/null 2>&1; then
         echo "    Runtime list command failed"
         return 1
     fi
     
-    echo "    Connected to remote host and runtime commands working"
+    echo "    Connected to $TEST_HOST and runtime commands working"
     return 0
 }
 
@@ -428,7 +421,7 @@ run_test_check "Test environment cleanup" test_cleanup
 echo -e "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${CYAN}  Test Summary${NC}"
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "Remote Host:    ${BLUE}$REMOTE_HOST${NC}"
+echo -e "Test Host:      ${BLUE}$TEST_HOST${NC}"
 echo -e "Total Tests:    $TOTAL_TESTS"
 echo -e "Passed:         ${GREEN}$PASSED_TESTS${NC}"
 echo -e "Failed:         ${RED}$FAILED_TESTS${NC}"
@@ -442,7 +435,7 @@ echo -e "\n${BLUE}Completed: $(date '+%Y-%m-%d %H:%M:%S')${NC}"
 
 if [[ $FAILED_TESTS -eq 0 ]]; then
     echo -e "\n${GREEN}✅ ALL RUNTIME LIFECYCLE TESTS PASSED!${NC}"
-    echo -e "${GREEN}Runtime management working correctly on $REMOTE_HOST${NC}"
+    echo -e "${GREEN}Runtime management working correctly on $TEST_HOST${NC}"
     exit 0
 else
     echo -e "\n${RED}❌ SOME RUNTIME LIFECYCLE TESTS FAILED${NC}"

--- a/tests/e2e/tests/03_network_test.sh
+++ b/tests/e2e/tests/03_network_test.sh
@@ -7,9 +7,7 @@
 # Source the test framework
 source "$(dirname "$0")/../lib/test_framework.sh"
 
-# Remote host configuration
-REMOTE_HOST="192.168.1.161"
-REMOTE_USER="jay"
+TEST_HOST="$(get_test_host_display)"
 
 # Test configuration
 CUSTOM_NETWORK_1="test-network-1"
@@ -21,13 +19,12 @@ CUSTOM_CIDR_2="10.100.2.0/24"
 # Helper Functions
 # ============================================
 
-# Run command on remote host via SSH (for host-level verification)
+# Run command on the test host (SSH when remote, local otherwise) for host-level verification
 run_ssh_command() {
     local command="$1"
     local timeout="${2:-10}"
-    
-    timeout "$timeout" ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no \
-        "$REMOTE_USER@$REMOTE_HOST" "$command" 2>/dev/null || echo "SSH_FAILED"
+
+    run_remote_command "$command" "$timeout"
 }
 
 # Verify host-level network interfaces (bridges, veth pairs, etc.)
@@ -145,7 +142,7 @@ cleanup_test_networks() {
 # ============================================
 
 test_bridge_network_interfaces() {
-    echo -e "    ${BLUE}Testing bridge network on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing bridge network on $TEST_HOST${NC}"
     
     local job_id=$(run_job_with_network "
         # Count network interfaces from /proc/net/dev
@@ -190,7 +187,7 @@ test_bridge_network_interfaces() {
 }
 
 test_bridge_internet_access() {
-    echo -e "    ${BLUE}Testing bridge network internet access on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing bridge network internet access on $TEST_HOST${NC}"
     
     local job_id=$(run_job_with_network "
         # Test internet connectivity using common tools
@@ -243,7 +240,7 @@ test_bridge_internet_access() {
 }
 
 test_bridge_dns_resolution() {
-    echo -e "    ${BLUE}Testing bridge network DNS resolution on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing bridge network DNS resolution on $TEST_HOST${NC}"
     
     # Use nslookup instead of Python for DNS testing to avoid runtime dependency issues
     local job_id=$(run_job_with_network "
@@ -286,7 +283,7 @@ test_bridge_dns_resolution() {
 # ============================================
 
 test_isolated_network_interfaces() {
-    echo -e "    ${BLUE}Testing isolated network interfaces on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing isolated network interfaces on $TEST_HOST${NC}"
     
     local job_id=$(run_job_with_network "
         # Count network interfaces from /proc/net/dev  
@@ -329,7 +326,7 @@ test_isolated_network_interfaces() {
 }
 
 test_isolated_internet_access() {
-    echo -e "    ${BLUE}Testing isolated network internet access on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing isolated network internet access on $TEST_HOST${NC}"
     
     local job_id=$(run_job_with_network "
         # Test internet connectivity using multiple methods
@@ -384,7 +381,7 @@ test_isolated_internet_access() {
 }
 
 test_isolated_no_inter_job_communication() {
-    echo -e "    ${BLUE}Testing network isolation between jobs on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing network isolation between jobs on $TEST_HOST${NC}"
     
     # Start first job in isolated network  
     local job1=$(run_job_with_network "
@@ -459,7 +456,7 @@ test_isolated_no_inter_job_communication() {
 # ============================================
 
 test_none_network_interfaces() {
-    echo -e "    ${BLUE}Testing none network interfaces on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing none network interfaces on $TEST_HOST${NC}"
     
     local job_id=$(run_job_with_network "
         # Count network interfaces from /proc/net/dev
@@ -499,7 +496,7 @@ test_none_network_interfaces() {
 }
 
 test_none_network_no_internet() {
-    echo -e "    ${BLUE}Testing none network blocks internet access on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing none network blocks internet access on $TEST_HOST${NC}"
 
     local job_id=$(run_job_with_network "
         # Test that internet connectivity is blocked in none network mode
@@ -580,7 +577,7 @@ test_none_network_no_internet() {
 }
 
 test_none_network_loopback_only() {
-    echo -e "    ${BLUE}Testing none network allows loopback only on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing none network allows loopback only on $TEST_HOST${NC}"
     
     local job_id=$(run_job_with_network "
         # Test that loopback connectivity works in none network mode
@@ -672,7 +669,7 @@ test_custom_network_listing() {
 }
 
 test_custom_network_inter_job_communication() {
-    echo -e "    ${BLUE}Testing inter-job communication in same custom network on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing inter-job communication in same custom network on $TEST_HOST${NC}"
     
     # Simplified approach: Test if jobs in same network can communicate using shell commands
     echo -e "    ${BLUE}Starting simple server in custom network...${NC}"
@@ -750,7 +747,7 @@ test_custom_network_inter_job_communication() {
 }
 
 test_custom_network_isolation_between_networks() {
-    echo -e "    ${BLUE}Testing network isolation between different custom networks on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing network isolation between different custom networks on $TEST_HOST${NC}"
     
     # Simplified approach: Test that jobs in different networks CANNOT communicate
     echo -e "    ${BLUE}Starting server in first custom network...${NC}"
@@ -836,7 +833,7 @@ test_custom_network_isolation_between_networks() {
 }
 
 test_custom_network_internet_access() {
-    echo -e "    ${BLUE}Testing custom network internet access on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing custom network internet access on $TEST_HOST${NC}"
     
     local job_id=$(run_job_with_network "
         # Test internet connectivity in custom network
@@ -898,7 +895,7 @@ main() {
     # Initialize test suite with remote host info
     echo -e "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${CYAN}  Comprehensive Network Configuration Tests${NC}"
-    echo -e "${CYAN}  Testing against remote host: ${REMOTE_HOST}${NC}"
+    echo -e "${CYAN}  Testing against: ${TEST_HOST}${NC}"
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${BLUE}Started: $(date '+%Y-%m-%d %H:%M:%S')${NC}\n"
     
@@ -906,14 +903,6 @@ main() {
     if ! check_prerequisites; then
         echo -e "${RED}Prerequisites check failed${NC}"
         exit 1
-    fi
-    
-    # Check RNX configuration points to remote host
-    if grep -q "$REMOTE_HOST" ~/.rnx/rnx-config.yml 2>/dev/null; then
-        echo -e "  ${GREEN}✓ RNX configured for remote host $REMOTE_HOST${NC}"
-    else
-        echo -e "  ${RED}✗ RNX not configured for remote host${NC}"
-        echo -e "  ${YELLOW}Warning: Tests may not be running against correct host${NC}"
     fi
     
     # Ensure runtime is available

--- a/tests/e2e/tests/05_volume_test.sh
+++ b/tests/e2e/tests/05_volume_test.sh
@@ -7,8 +7,7 @@
 source "$(dirname "$0")/../lib/test_framework.sh"
 
 # Remote host configuration
-REMOTE_HOST="192.168.1.161"
-REMOTE_USER="jay"
+TEST_HOST="$(get_test_host_display)"
 
 # Test configuration
 TEST_VOLUME_NAME="test-volume-$$"
@@ -67,7 +66,7 @@ test_upload_file() {
     echo "$TEST_DATA" > "$test_file"
     local uploaded_basename=$(basename "$test_file")
     
-    echo -e "    ${BLUE}Testing file upload to remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing file upload to $TEST_HOST${NC}"
     
     local job_output=$("$RNX_BINARY" job run \
         --upload="$test_file" \
@@ -150,7 +149,7 @@ test_volume_creation() {
 
 test_volume_mounting() {
     # Test mounting a volume to a job with remote host verification
-    echo -e "    ${BLUE}Testing volume mounting on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing volume mounting on $TEST_HOST${NC}"
     
     local job_output=$("$RNX_BINARY" job run \
         --volume="$TEST_VOLUME_NAME:/data" \
@@ -198,7 +197,7 @@ fi
 
 test_volume_persistence() {
     # Test that data persists across jobs with remote host verification
-    echo -e "    ${BLUE}Testing data persistence isolation on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing data persistence isolation on $TEST_HOST${NC}"
     
     # First job: write data to /work
     local job1_output=$("$RNX_BINARY" job run sh -c "
@@ -277,7 +276,7 @@ test_concurrent_volume_access() {
 
 test_volume_size_limits() {
     # Test volume size restrictions with remote host verification
-    echo -e "    ${BLUE}Testing volume size limits on remote host $REMOTE_HOST${NC}"
+    echo -e "    ${BLUE}Testing volume size limits on $TEST_HOST${NC}"
     
     local job_output=$("$RNX_BINARY" job run sh -c "
 # Try to write a large file (10MB)
@@ -352,7 +351,7 @@ main() {
     # Initialize test suite
     echo -e "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${CYAN}  Volume Management Tests${NC}"
-    echo -e "${CYAN}  Testing against remote host: ${REMOTE_HOST}${NC}"
+    echo -e "${CYAN}  Testing against: ${TEST_HOST}${NC}"
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${BLUE}Started: $(date '+%Y-%m-%d %H:%M:%S')${NC}\n"
     
@@ -360,14 +359,6 @@ main() {
     if ! check_prerequisites; then
         echo -e "${RED}Prerequisites check failed${NC}"
         exit 1
-    fi
-    
-    # Check RNX configuration points to remote host
-    if grep -q "$REMOTE_HOST" ~/.rnx/rnx-config.yml 2>/dev/null; then
-        echo -e "  ${GREEN}✓ RNX configured for remote host $REMOTE_HOST${NC}"
-    else
-        echo -e "  ${RED}✗ RNX not configured for remote host${NC}"
-        echo -e "  ${YELLOW}Warning: Tests may not be running against correct host${NC}"
     fi
     
     # No runtime required - using basic shell commands
@@ -395,7 +386,7 @@ main() {
     echo -e "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${CYAN}  Volume Management Tests Summary${NC}"
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo -e "Remote Host:    ${BLUE}$REMOTE_HOST${NC}"
+    echo -e "Test Host:      ${BLUE}$TEST_HOST${NC}"
     echo -e "Total Tests:    $TOTAL_TESTS"
     echo -e "Passed:         ${GREEN}$PASSED_TESTS${NC}"
     echo -e "Failed:         ${RED}$FAILED_TESTS${NC}"
@@ -410,7 +401,7 @@ main() {
     
     if [[ $FAILED_TESTS -eq 0 && $TOTAL_TESTS -gt 0 ]]; then
         echo -e "\n${GREEN}✅ ALL VOLUME TESTS PASSED!${NC}"
-        echo -e "${GREEN}Volume management is working correctly on $REMOTE_HOST${NC}"
+        echo -e "${GREEN}Volume management is working correctly on $TEST_HOST${NC}"
         exit 0
     elif [[ $FAILED_TESTS -gt 0 ]]; then
         echo -e "\n${RED}❌ SOME VOLUME TESTS FAILED${NC}"

--- a/tests/e2e/tests/09_gpu_test.sh
+++ b/tests/e2e/tests/09_gpu_test.sh
@@ -12,7 +12,7 @@ source "$(dirname "$0")/../lib/test_framework.sh"
 
 # Check if we should run GPU tests
 GPU_TEST_MODE="${GPU_TEST_MODE:-mock}"  # mock, real, skip
-REMOTE_HOST="${REMOTE_HOST:-192.168.1.161}"
+TEST_HOST="$(get_test_host_display)"
 
 # ============================================
 # GPU Test Helper Functions
@@ -211,7 +211,7 @@ main() {
     fi
 
     echo -e "${CYAN}GPU Test Mode: $GPU_TEST_MODE${NC}"
-    echo -e "${CYAN}Remote Host: $REMOTE_HOST${NC}"
+    echo -e "${CYAN}Test Host: $TEST_HOST${NC}"
 
     test_section "GPU Flag Parsing"
     run_test "GPU flag parsing" test_gpu_flag_parsing

--- a/tests/e2e/tests/10_persist_test.sh
+++ b/tests/e2e/tests/10_persist_test.sh
@@ -7,9 +7,7 @@
 # Source the test framework
 source "$(dirname "$0")/../lib/test_framework.sh"
 
-# Remote host configuration (consistent with other tests)
-REMOTE_HOST="${REMOTE_HOST:-192.168.1.161}"
-REMOTE_USER="${REMOTE_USER:-jay}"
+# Target host comes from the framework (local by default, JOBLET_TEST_HOST for remote)
 
 # Initialize test suite
 test_suite_init "Persist Subprocess Integration Tests"
@@ -22,12 +20,12 @@ test_persist_service_running() {
     echo "Checking if persist subprocess is running..."
 
     # Check if persist is running as subprocess of joblet
-    local persist_pid=$(ssh ${REMOTE_USER}@${REMOTE_HOST} "ps aux | grep '/persist' | grep -v grep | awk '{print \$2}'" 2>/dev/null)
-    local joblet_pid=$(ssh ${REMOTE_USER}@${REMOTE_HOST} "ps aux | grep '/opt/joblet/bin/joblet\$' | grep -v grep | awk '{print \$2}'" 2>/dev/null)
+    local persist_pid=$(run_remote_command "ps aux | grep '/persist' | grep -v grep | awk '{print \$2}'" 2>/dev/null)
+    local joblet_pid=$(run_remote_command "ps aux | grep '/opt/joblet/bin/joblet\$' | grep -v grep | awk '{print \$2}'" 2>/dev/null)
 
     if [[ -n "$persist_pid" ]] && [[ -n "$joblet_pid" ]]; then
         # Verify persist is a child of joblet
-        local parent_pid=$(ssh ${REMOTE_USER}@${REMOTE_HOST} "ps -o ppid= -p $persist_pid" 2>/dev/null | tr -d ' ')
+        local parent_pid=$(run_remote_command "ps -o ppid= -p $persist_pid" 2>/dev/null | tr -d ' ')
 
         if [[ "$parent_pid" == "$joblet_pid" ]]; then
             echo "  ✓ persist subprocess is running (PID: $persist_pid, Parent: $joblet_pid)"
@@ -41,7 +39,7 @@ test_persist_service_running() {
         echo "  ✗ persist subprocess is not running"
         echo "    Joblet PID: ${joblet_pid:-not found}"
         echo "    Persist PID: ${persist_pid:-not found}"
-        ssh ${REMOTE_USER}@${REMOTE_HOST} "ps auxf | grep joblet | grep -v grep" || true
+        run_remote_command "ps auxf | grep joblet | grep -v grep" || true
         return 1
     fi
 }
@@ -50,16 +48,16 @@ test_persist_socket_exists() {
     echo "Checking if persist Unix socket exists..."
 
     # Socket path is /opt/joblet/run/persist-ipc.sock
-    if ssh ${REMOTE_USER}@${REMOTE_HOST} "sudo ss -xlnp | grep persist-ipc.sock" 2>/dev/null | grep -q "persist"; then
+    if run_remote_command "sudo ss -xlnp | grep persist-ipc.sock" 2>/dev/null | grep -q "persist"; then
         echo "  ✓ Persist IPC socket exists at /opt/joblet/run/persist-ipc.sock"
         return 0
-    elif ssh ${REMOTE_USER}@${REMOTE_HOST} "sudo ls -la /opt/joblet/run/persist-ipc.sock" 2>/dev/null | grep -q "persist-ipc.sock"; then
+    elif run_remote_command "sudo ls -la /opt/joblet/run/persist-ipc.sock" 2>/dev/null | grep -q "persist-ipc.sock"; then
         echo "  ✓ Persist IPC socket file exists at /opt/joblet/run/persist-ipc.sock"
         return 0
     else
         echo "  ✗ Persist socket does not exist"
         echo "  Checking socket locations:"
-        ssh ${REMOTE_USER}@${REMOTE_HOST} "sudo ss -xlnp | grep persist || echo 'No persist sockets found'" 2>/dev/null
+        run_remote_command "sudo ss -xlnp | grep persist || echo 'No persist sockets found'" 2>/dev/null
         return 1
     fi
 }
@@ -118,10 +116,15 @@ test_metric_persistence() {
 
     # Test metrics via streaming API (telemetry collector)
     # The metrics command streams from the telemetry collector
-    local metrics_output=$(timeout 10 ssh ${REMOTE_USER}@${REMOTE_HOST} "rnx job metrics $job_id" 2>&1 || true)
+    local metrics_output
+    if [[ "$JOBLET_TEST_USE_SSH" == "true" ]]; then
+        metrics_output=$(timeout 10 ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no "$JOBLET_TEST_USER@$JOBLET_TEST_HOST" "rnx job metrics $job_id" 2>&1 || true)
+    else
+        metrics_output=$(timeout 10 "$RNX_BINARY" job metrics "$job_id" 2>&1 || true)
+    fi
 
     # Check if we got any metrics samples
-    local sample_count=$(echo "$metrics_output" | grep -c "Metrics at" 2>/dev/null || echo "0")
+    local sample_count=$(echo "$metrics_output" | grep -c "Metrics at" 2>/dev/null || true)
 
     if [[ "$sample_count" -gt 0 ]]; then
         echo "  ✓ Metrics streaming working - received $sample_count samples"
@@ -158,7 +161,7 @@ test_log_directory_structure() {
     sleep 3
 
     # Check log directory structure
-    local log_dir=$(ssh ${REMOTE_USER}@${REMOTE_HOST} "sudo ls -la /opt/joblet/logs/$job_id/" 2>/dev/null)
+    local log_dir=$(run_remote_command "sudo ls -la /opt/joblet/logs/$job_id/" 2>/dev/null)
 
     if echo "$log_dir" | grep -q "stdout.log.gz"; then
         echo "  ✓ stdout.log.gz exists"
@@ -200,7 +203,7 @@ test_multiple_jobs_persistence() {
     # Verify logs for all jobs
     local success_count=0
     for job_id in "${job_ids[@]}"; do
-        if ssh ${REMOTE_USER}@${REMOTE_HOST} "sudo ls /opt/joblet/logs/$job_id/stdout.log.gz" 2>/dev/null; then
+        if run_remote_command "sudo ls /opt/joblet/logs/$job_id/stdout.log.gz" 2>/dev/null; then
             ((success_count++))
         fi
     done
@@ -218,7 +221,7 @@ test_persist_service_logs() {
     echo "Checking persist subprocess logs for errors..."
 
     # Persist logs are now in joblet service logs with [PERSIST] prefix
-    local logs=$(ssh ${REMOTE_USER}@${REMOTE_HOST} "sudo journalctl -u joblet.service --since '5 minutes ago' --no-pager | grep '\[PERSIST\]'" 2>&1)
+    local logs=$(run_remote_command "sudo journalctl -u joblet.service --since '5 minutes ago' --no-pager | grep '\[PERSIST\]'" 2>&1)
 
     # Check for error patterns
     if echo "$logs" | grep -qi "panic\|fatal\|\[ERROR\].*failed"; then
@@ -238,7 +241,7 @@ test_ipc_socket_permissions() {
     echo "Testing IPC socket permissions..."
 
     # Check if socket is accessible and listening
-    local socket_info=$(ssh ${REMOTE_USER}@${REMOTE_HOST} "sudo ss -xlnp | grep persist-ipc.sock" 2>&1)
+    local socket_info=$(run_remote_command "sudo ss -xlnp | grep persist-ipc.sock" 2>&1)
 
     if echo "$socket_info" | grep -q "LISTEN"; then
         echo "  ✓ Socket is listening and accessible"
@@ -253,7 +256,7 @@ test_ipc_socket_permissions() {
 test_persist_binary_version() {
     echo "Checking persist binary version..."
 
-    local version=$(ssh ${REMOTE_USER}@${REMOTE_HOST} "/opt/joblet/bin/persist version 2>&1" || echo "version command not available")
+    local version=$(run_remote_command "/opt/joblet/bin/persist version 2>&1" || echo "version command not available")
 
     echo "  Persist version: $version"
 
@@ -269,8 +272,8 @@ test_persist_binary_version() {
 test_storage_disk_usage() {
     echo "Checking storage disk usage..."
 
-    local logs_size=$(ssh ${REMOTE_USER}@${REMOTE_HOST} "sudo du -sh /opt/joblet/logs 2>/dev/null | cut -f1" || echo "unknown")
-    local metrics_size=$(ssh ${REMOTE_USER}@${REMOTE_HOST} "sudo du -sh /opt/joblet/metrics 2>/dev/null | cut -f1" || echo "unknown")
+    local logs_size=$(run_remote_command "sudo du -sh /opt/joblet/logs 2>/dev/null | cut -f1" || echo "unknown")
+    local metrics_size=$(run_remote_command "sudo du -sh /opt/joblet/metrics 2>/dev/null | cut -f1" || echo "unknown")
 
     echo "  Logs storage: $logs_size"
     echo "  Metrics storage: $metrics_size"

--- a/tests/e2e/tests/11_metrics_gap_test.sh
+++ b/tests/e2e/tests/11_metrics_gap_test.sh
@@ -9,19 +9,13 @@
 #
 # Examples:
 #   ./11_metrics_gap_test.sh                                    # Test locally
-#   JOBLET_TEST_HOST=192.168.1.161 ./11_metrics_gap_test.sh   # Test remote host
+#   JOBLET_TEST_HOST=192.0.2.10 ./11_metrics_gap_test.sh   # Test remote host
 
 # Source test framework
 source "$(dirname "$0")/../lib/test_framework.sh"
 
-# Remote host configuration (consistent with other tests)
-REMOTE_HOST="${REMOTE_HOST:-192.168.1.161}"
-REMOTE_USER="${REMOTE_USER:-jay}"
-
-# Set JOBLET_TEST_HOST for test framework's run_rnx_command to work
-export JOBLET_TEST_HOST="$REMOTE_HOST"
-export JOBLET_TEST_USER="$REMOTE_USER"
-export JOBLET_TEST_USE_SSH="true"
+# Target host comes from the framework (local by default, JOBLET_TEST_HOST for remote)
+TEST_HOST="$(get_test_host_display)"
 
 # Test configuration
 # Note: Metrics collection is automatic, no interval flag needed
@@ -30,13 +24,12 @@ export JOBLET_TEST_USE_SSH="true"
 # Helper Functions
 # ============================================
 
-# Run command on remote host via SSH (for host-level verification)
+# Run command on the test host (SSH when remote, local otherwise) for host-level verification
 run_ssh_command() {
     local command="$1"
     local timeout="${2:-10}"
 
-    timeout "$timeout" ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no \
-        "$REMOTE_USER@$REMOTE_HOST" "$command" 2>/dev/null || echo "SSH_FAILED"
+    run_remote_command "$command" "$timeout"
 }
 
 # Start a metrics test job
@@ -169,7 +162,7 @@ test_gap_detection() {
 
     # Extract timestamps from metrics output
     local timestamps=$(get_timestamps "$full_metrics")
-    local timestamp_count=$(echo "$timestamps" | grep -c ":" || echo "0")
+    local timestamp_count=$(echo "$timestamps" | grep -c ":" || true)
 
     # With current metrics collection behavior, we typically get 2-3 samples
     # Require at least 2 samples to test gap detection (buffer → live transition)
@@ -283,7 +276,7 @@ main() {
     # Initialize test suite
     echo -e "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${CYAN}  Metrics Gap Prevention Tests${NC}"
-    echo -e "${CYAN}  Testing against remote host: ${REMOTE_HOST}${NC}"
+    echo -e "${CYAN}  Testing against: ${TEST_HOST}${NC}"
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${BLUE}Started: $(date '+%Y-%m-%d %H:%M:%S')${NC}\n"
 
@@ -293,12 +286,12 @@ main() {
         exit 1
     fi
 
-    # Verify SSH connectivity to remote host
-    if ! run_ssh_command "echo 'SSH_OK'" | grep -q "SSH_OK"; then
-        echo -e "${RED}Cannot connect to remote host $REMOTE_HOST${NC}"
+    # Verify connectivity to the test host
+    if ! run_ssh_command "echo 'HOST_OK'" | grep -q "HOST_OK"; then
+        echo -e "${RED}Cannot connect to test host $TEST_HOST${NC}"
         exit 1
     fi
-    echo -e "  ${GREEN}✓ Connected to remote host $REMOTE_HOST${NC}\n"
+    echo -e "  ${GREEN}✓ Connected to test host $TEST_HOST${NC}\n"
 
     # Track test results
     local tests_passed=0
@@ -379,7 +372,7 @@ main() {
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${CYAN}  Test Summary${NC}"
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo "Remote Host:    ${BLUE}${REMOTE_HOST}${NC}"
+    echo "Test Host:      ${BLUE}${TEST_HOST}${NC}"
     echo "Total Tests:    $tests_total"
     echo "Passed:         ${GREEN}${tests_passed}${NC}"
     echo "Failed:         ${RED}${tests_failed}${NC}"

--- a/tests/e2e/tests/13_log_gap_live_test.sh
+++ b/tests/e2e/tests/13_log_gap_live_test.sh
@@ -12,14 +12,20 @@
 # Source test framework
 source "$(dirname "$0")/../lib/test_framework.sh"
 
-# Remote host configuration
-REMOTE_HOST="${REMOTE_HOST:-192.168.1.161}"
-REMOTE_USER="${REMOTE_USER:-jay}"
+# Target host comes from the framework (local by default, JOBLET_TEST_HOST for remote)
 
-# Set JOBLET_TEST_HOST for test framework
-export JOBLET_TEST_HOST="$REMOTE_HOST"
-export JOBLET_TEST_USER="$REMOTE_USER"
-export JOBLET_TEST_USE_SSH="true"
+# Stream job logs for a bounded time (SSH when remote, local otherwise)
+stream_job_logs() {
+    local job_id="$1"
+    local duration="$2"
+    local output_file="$3"
+
+    if [[ "$JOBLET_TEST_USE_SSH" == "true" ]]; then
+        timeout "$duration" ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no "$JOBLET_TEST_USER@$JOBLET_TEST_HOST" "rnx job log '$job_id'" > "$output_file" 2>&1 || true
+    else
+        timeout "$duration" "$RNX_BINARY" job log "$job_id" > "$output_file" 2>&1 || true
+    fi
+}
 
 # Initialize test suite
 test_suite_init "Live Log Gap Prevention Tests"
@@ -54,8 +60,7 @@ test_live_log_streaming_no_gaps() {
     trap "rm -f $log_output" EXIT
 
     # Stream logs for 8 seconds (enough to get rest of job + ensure completion)
-    # Use SSH directly instead of through run_rnx_command to avoid timeout issues with bash functions
-    timeout 8 ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no "$REMOTE_USER@$REMOTE_HOST" "rnx job log '$job_id'" > "$log_output" 2>&1 || true
+    stream_job_logs "$job_id" 8 "$log_output"
 
     # Wait for job to complete
     sleep 2
@@ -159,8 +164,7 @@ test_live_log_streaming_early_check() {
     trap "rm -f $log_output" EXIT
 
     # Stream for 5 seconds
-    # Use SSH directly instead of through run_rnx_command to avoid timeout issues
-    timeout 5 ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no "$REMOTE_USER@$REMOTE_HOST" "rnx job log '$job_id'" > "$log_output" 2>&1 || true
+    stream_job_logs "$job_id" 5 "$log_output"
 
     # Count logs (filter out DEBUG lines)
     local total=$(grep "^Early [0-9]" "$log_output" 2>/dev/null | wc -l || echo "0")

--- a/tests/e2e/tests/15_state_load_test.sh
+++ b/tests/e2e/tests/15_state_load_test.sh
@@ -7,9 +7,7 @@
 # Source the test framework
 source "$(dirname "$0")/../lib/test_framework.sh"
 
-# Remote host configuration
-REMOTE_HOST="${JOBLET_TEST_HOST:-192.168.1.161}"
-REMOTE_USER="${JOBLET_TEST_USER:-jay}"
+# Target host comes from the framework (local by default, JOBLET_TEST_HOST for remote)
 
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${CYAN}  State Client Load Test (1000+ Concurrent Jobs)${NC}"
@@ -45,7 +43,7 @@ test_state_service_running() {
     TOTAL_TESTS=$((TOTAL_TESTS + 1))
 
     # Check if state socket exists on remote host
-    if ssh "${REMOTE_USER}@${REMOTE_HOST}" "test -S ${STATE_SOCKET}" 2>/dev/null; then
+    if [[ "$(run_remote_command "test -S ${STATE_SOCKET} && echo EXISTS")" == *EXISTS* ]]; then
         echo -e "  ${GREEN}✓ State socket exists${NC}"
         PASSED_TESTS=$((PASSED_TESTS + 1))
     else
@@ -102,8 +100,7 @@ test_rapid_job_creation() {
     # Check job completion
     sleep 5  # Give jobs time to complete
 
-    local completed_count=$(ssh "${REMOTE_USER}@${REMOTE_HOST}" \
-        "$RNX_BINARY job list 2>/dev/null | grep 'COMPLETED' | grep -c 'load-test-' || echo 0")
+    local completed_count=$(run_rnx_command "job list" | grep 'COMPLETED' | grep -c 'load-test-' || echo 0)
     # Ensure we have a valid number (default to 0 if empty or invalid)
     completed_count=${completed_count:-0}
     completed_count=$(echo "$completed_count" | tr -d '\n')
@@ -185,8 +182,7 @@ test_connection_pool_stats() {
     echo -e "  ${BLUE}Checking connection pool metrics...${NC}"
 
     local log_file="/opt/joblet/logs/joblet.log"
-    local recent_stats=$(ssh "${REMOTE_USER}@${REMOTE_HOST}" \
-        "tail -1000 ${log_file} 2>/dev/null | grep -i 'pool.*stat' | tail -1" || echo "")
+    local recent_stats=$(run_remote_command "tail -1000 ${log_file} 2>/dev/null | grep -i 'pool.*stat' | tail -1" || echo "")
 
     if [[ -n "$recent_stats" ]]; then
         echo -e "  ${BLUE}Recent pool stats:${NC}"

--- a/tests/e2e/tests/16_ebpf_telemetry_test.sh
+++ b/tests/e2e/tests/16_ebpf_telemetry_test.sh
@@ -7,10 +7,6 @@
 # Source the test framework
 source "$(dirname "$0")/../lib/test_framework.sh"
 
-# Remote host configuration (consistent with other tests)
-REMOTE_HOST="${REMOTE_HOST:-192.168.1.161}"
-REMOTE_USER="${REMOTE_USER:-jay}"
-
 # Initialize test suite
 test_suite_init "eBPF Telematics Tests"
 

--- a/tests/e2e/tests/17_telematics_gap_test.sh
+++ b/tests/e2e/tests/17_telematics_gap_test.sh
@@ -56,13 +56,13 @@ test_telematics_live_streaming_no_gaps() {
     echo -e "${BLUE}Analyzing telematics event completeness...${NC}"
 
     # Count EXEC events for /usr/bin/sleep
-    local exec_count=$(grep "EXEC" "$vis_output" 2>/dev/null | grep -c "sleep" 2>/dev/null || echo 0)
+    local exec_count=$(grep "EXEC" "$vis_output" 2>/dev/null | grep -c "sleep" 2>/dev/null || true)
     exec_count=$(echo "$exec_count" | tr -d '[:space:]')
     echo -e "  Total EXEC (sleep) events: $exec_count/200"
 
     # Extract PIDs to check for duplicates and gaps
     local pids=$(grep "EXEC" "$vis_output" 2>/dev/null | grep "sleep" | awk -F'pid=' '{print $2}' | awk '{print $1}' | sort -n)
-    local unique_pids=$(echo "$pids" | sort -u | grep -c "[0-9]" 2>/dev/null || echo 0)
+    local unique_pids=$(echo "$pids" | sort -u | grep -c "[0-9]" 2>/dev/null || true)
     unique_pids=$(echo "$unique_pids" | tr -d '[:space:]')
     echo -e "  Unique PIDs: $unique_pids"
 
@@ -116,7 +116,7 @@ test_telematics_early_check() {
     timeout 8 $RNX_BINARY job telematics "$job_id" 2>&1 | sed 's/\x1b\[[0-9;]*m//g' > "$vis_output" || true
 
     # Count EXEC events
-    local exec_count=$(grep -c "EXEC" "$vis_output" 2>/dev/null || echo 0)
+    local exec_count=$(grep -c "EXEC" "$vis_output" 2>/dev/null || true)
     exec_count=$(echo "$exec_count" | tr -d '[:space:]')
     echo -e "  EXEC events received: $exec_count"
 
@@ -159,7 +159,7 @@ test_telematics_for_completed_job() {
     timeout 10 $RNX_BINARY job telematics "$job_id" 2>&1 | sed 's/\x1b\[[0-9;]*m//g' > "$vis_output" || true
 
     # Count EXEC events (expect at least bash + 10 sleep calls)
-    local exec_count=$(grep -c "EXEC" "$vis_output" 2>/dev/null || echo 0)
+    local exec_count=$(grep -c "EXEC" "$vis_output" 2>/dev/null || true)
     exec_count=$(echo "$exec_count" | tr -d '[:space:]')
     echo -e "  EXEC events received: $exec_count"
 
@@ -203,7 +203,7 @@ test_telematics_gap_detection() {
     timeout 12 $RNX_BINARY job telematics "$job_id" 2>&1 | sed 's/\x1b\[[0-9;]*m//g' > "$vis_output" || true
 
     # Extract timestamps from EXEC events
-    local timestamp_count=$(grep "EXEC" "$vis_output" 2>/dev/null | grep -c "sleep" 2>/dev/null || echo 0)
+    local timestamp_count=$(grep "EXEC" "$vis_output" 2>/dev/null | grep -c "sleep" 2>/dev/null || true)
     timestamp_count=$(echo "$timestamp_count" | tr -d '[:space:]')
 
     echo -e "  Events captured: $timestamp_count"
@@ -248,9 +248,9 @@ test_telematics_deduplication() {
 
     # Extract PIDs and check for exact duplicates
     local pids=$(grep "EXEC" "$vis_output" 2>/dev/null | grep "sleep" | awk -F'pid=' '{print $2}' | awk '{print $1}')
-    local total=$(echo "$pids" | grep -c "[0-9]" 2>/dev/null || echo 0)
+    local total=$(echo "$pids" | grep -c "[0-9]" 2>/dev/null || true)
     total=$(echo "$total" | tr -d '[:space:]')
-    local unique=$(echo "$pids" | sort -u | grep -c "[0-9]" 2>/dev/null || echo 0)
+    local unique=$(echo "$pids" | sort -u | grep -c "[0-9]" 2>/dev/null || true)
     unique=$(echo "$unique" | tr -d '[:space:]')
 
     # Cleanup


### PR DESCRIPTION
This PR introduces four-role RBAC and, while validating it end to end on real hardware, hardens the areas that validation exposed: config handling, the install/uninstall lifecycle, data-loss windows in log/metric/telemetry streaming, and the developer verification workflow itself.

## Four-role authorization                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                            
- Replaces the two-role scheme with **admin / maintainer / developer / reader**,  enforced via mTLS certificate OUs; legacy `viewer` OUs map to `reader`                                                                                                                                                                                                                                              
- A certificate carrying multiple role OUs gets the least-privileged role                                                                                                                                                                                                                                             
- Installer generates per-role client certs and configs (`rnx-config-<role>.yml`); the combined admin config stays on the server  

## Behavioral changes                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                 
- Server **will not start** without a config file (previously ran on defaults),  intentional fail-fast; a broken install now surfaces immediately                                                                                                                                                                                                                                                    
- `make deploy` now targets **localhost** (use `REMOTE_HOST=<ip>` for the old behavior); builds default to the **native** architecture                                                                                                                                                                                                                                                            
- `viewer` certificates keep working (mapped to `reader`)    
