### PR TITLE
fix: installation network conflict

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -49,15 +49,18 @@ jobs:
 
       - name: Build all binaries
         run: |
-          LDFLAGS="-X main.version=${{ steps.version.outputs.version }} -w -s"
+          # Inject version info into pkg/version (same variables the Makefile sets)
+          VPKG="github.com/ehsaniara/joblet/pkg/version"
+          BUILD_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          LDFLAGS="-s -w -X ${VPKG}.Version=${{ steps.version.outputs.version }} -X ${VPKG}.GitCommit=${GITHUB_SHA} -X ${VPKG}.GitTag=${{ steps.version.outputs.version }} -X ${VPKG}.BuildDate=${BUILD_DATE}"
 
           # Main binaries
-          GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -ldflags "$LDFLAGS" -o joblet-${{ matrix.arch }} ./cmd/joblet
-          GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -ldflags "$LDFLAGS" -o rnx-${{ matrix.arch }} ./cmd/rnx
+          GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -ldflags "$LDFLAGS -X ${VPKG}.Component=joblet" -o joblet-${{ matrix.arch }} ./cmd/joblet
+          GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -ldflags "$LDFLAGS -X ${VPKG}.Component=rnx" -o rnx-${{ matrix.arch }} ./cmd/rnx
 
           # Submodule binaries
-          cd persist && GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -ldflags "$LDFLAGS" -o ../persist-${{ matrix.arch }} ./cmd/persist && cd ..
-          cd state && GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -ldflags "$LDFLAGS" -o ../state-${{ matrix.arch }} ./cmd/state && cd ..
+          cd persist && GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -ldflags "$LDFLAGS -X ${VPKG}.Component=persist" -o ../persist-${{ matrix.arch }} ./cmd/persist && cd ..
+          cd state && GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -ldflags "$LDFLAGS -X ${VPKG}.Component=state" -o ../state-${{ matrix.arch }} ./cmd/state && cd ..
 
           ls -la *-${{ matrix.arch }}
 
@@ -306,7 +309,9 @@ jobs:
       - name: Build cross-platform CLI
         run: |
           mkdir -p dist
-          LDFLAGS="-X main.version=${{ steps.version.outputs.version }} -w -s"
+          VPKG="github.com/ehsaniara/joblet/pkg/version"
+          BUILD_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          LDFLAGS="-s -w -X ${VPKG}.Version=${{ steps.version.outputs.version }} -X ${VPKG}.GitCommit=${GITHUB_SHA} -X ${VPKG}.GitTag=${{ steps.version.outputs.version }} -X ${VPKG}.BuildDate=${BUILD_DATE} -X ${VPKG}.Component=rnx"
 
           # Linux
           GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/rnx-linux-amd64 ./cmd/rnx

--- a/scripts/common-install-functions.sh
+++ b/scripts/common-install-functions.sh
@@ -139,8 +139,10 @@ check_network_conflicts() {
     print_info "Checking for network conflicts..."
 
     # Check if the network range is already in use
-    if ip route | grep -q "172.20."; then
-        local conflicting_route=$(ip route | grep "172.20." | head -1)
+    # A route on our own joblet0 bridge is not a conflict - it is the
+    # leftover from a previous install (normal during upgrades) and gets reused
+    if ip route | grep "172.20." | grep -qv "dev joblet0"; then
+        local conflicting_route=$(ip route | grep "172.20." | grep -v "dev joblet0" | head -1)
         print_error "Network conflict detected!"
         print_error "The 172.20.0.0/16 range is already in use: $conflicting_route"
         print_warning "Joblet requires 172.20.0.0/16 for job isolation"
@@ -151,7 +153,7 @@ check_network_conflicts() {
 
     # Check if bridge already exists
     if ip link show joblet0 >/dev/null 2>&1; then
-        print_warning "Bridge joblet0 already exists, will reuse it"
+        print_warning "Bridge joblet0 already exists (previous install), will reuse it"
         return 0
     fi
 


### PR DESCRIPTION
 the `172.20.0.0/16` conflict check now excludes routes on `joblet0` itself, a leftover `bridge` from a previous install is normal during upgrades and gets reused, not warned about. Real conflicts (the range occupied by any other interface) still trigger the full warning. 