### PR TITLE
reject path traversal in job file uploads (arbitrary root write on host

### DIFF
--- a/internal/joblet/core/execution/environment_service.go
+++ b/internal/joblet/core/execution/environment_service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ehsaniara/joblet/internal/joblet/core/environment"
 	"github.com/ehsaniara/joblet/internal/joblet/core/upload"
+	"github.com/ehsaniara/joblet/internal/joblet/core/validation"
 	"github.com/ehsaniara/joblet/internal/joblet/domain"
 	"github.com/ehsaniara/joblet/pkg/config"
 	"github.com/ehsaniara/joblet/pkg/logger"
@@ -149,7 +150,7 @@ func (es *EnvironmentService) processUploads(uploads []domain.FileUpload, workDi
 	for _, upload := range uploads {
 		// SECURITY: uploads are written as root on the host before any chroot
 		// exists; a client-supplied "../" path would escape the workspace.
-		fullPath, err := domain.ResolveUploadPath(workDir, upload.Path)
+		fullPath, err := validation.ValidatePathWithinBase(workDir, upload.Path)
 		if err != nil {
 			return err
 		}

--- a/internal/joblet/core/execution/environment_service.go
+++ b/internal/joblet/core/execution/environment_service.go
@@ -147,10 +147,16 @@ func (es *EnvironmentService) processUploads(uploads []domain.FileUpload, workDi
 	es.logger.Debug("processing uploads", "count", len(uploads), "workDir", workDir)
 
 	for _, upload := range uploads {
-		fullPath := filepath.Join(workDir, upload.Path)
+		// SECURITY: uploads are written as root on the host before any chroot
+		// exists; a client-supplied "../" path would escape the workspace.
+		fullPath, err := domain.ResolveUploadPath(workDir, upload.Path)
+		if err != nil {
+			return err
+		}
+		mode := domain.SanitizeUploadMode(upload.Mode)
 
 		if upload.IsDirectory {
-			if err := os.MkdirAll(fullPath, os.FileMode(upload.Mode)); err != nil {
+			if err := os.MkdirAll(fullPath, mode); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", upload.Path, err)
 			}
 		} else {
@@ -158,7 +164,7 @@ func (es *EnvironmentService) processUploads(uploads []domain.FileUpload, workDi
 				return fmt.Errorf("failed to create parent directory for %s: %w", upload.Path, err)
 			}
 
-			if err := os.WriteFile(fullPath, upload.Content, os.FileMode(upload.Mode)); err != nil {
+			if err := os.WriteFile(fullPath, upload.Content, mode); err != nil {
 				return fmt.Errorf("failed to write file %s: %w", upload.Path, err)
 			}
 		}

--- a/internal/joblet/core/execution/upload_security_test.go
+++ b/internal/joblet/core/execution/upload_security_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/ehsaniara/joblet/pkg/logger"
 )
 
-// TestProcessUploadsRejectsTraversal is the regression test for issue #1:
-// a client-supplied "../" upload path must be rejected before any write, and
-// nothing may be written outside the workspace. processUploads runs as root
-// on the host before chroot, so an escape is host compromise.
+// TestProcessUploadsRejectsTraversal verifies that a client-supplied "../"
+// upload path is rejected before any write and nothing lands outside the
+// workspace. processUploads runs as root on the host before chroot, so an
+// escaping path would be an arbitrary host file-write.
 func TestProcessUploadsRejectsTraversal(t *testing.T) {
 	root := t.TempDir()
 	workDir := filepath.Join(root, "jobs", "abc", "work")

--- a/internal/joblet/core/execution/upload_security_test.go
+++ b/internal/joblet/core/execution/upload_security_test.go
@@ -1,0 +1,66 @@
+package execution
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ehsaniara/joblet/internal/joblet/domain"
+	"github.com/ehsaniara/joblet/pkg/logger"
+)
+
+// TestProcessUploadsRejectsTraversal is the regression test for issue #1:
+// a client-supplied "../" upload path must be rejected before any write, and
+// nothing may be written outside the workspace. processUploads runs as root
+// on the host before chroot, so an escape is host compromise.
+func TestProcessUploadsRejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(root, "jobs", "abc", "work")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(root, "escaped")
+
+	es := &EnvironmentService{logger: logger.New()}
+
+	// Traversal escape must be rejected and must not write the sentinel.
+	err := es.processUploads([]domain.FileUpload{{
+		Path:    "../../../escaped",
+		Content: []byte("pwned"),
+		Mode:    0o644,
+	}}, workDir)
+	if err == nil {
+		t.Fatal("processUploads accepted a traversal path; expected rejection")
+	}
+	if _, statErr := os.Stat(sentinel); statErr == nil {
+		t.Fatalf("traversal wrote outside the workspace at %s", sentinel)
+	}
+
+	// A legitimate in-workspace upload still works and lands inside workDir.
+	if err := es.processUploads([]domain.FileUpload{{
+		Path:    "src/main.go",
+		Content: []byte("package main"),
+		Mode:    0o644,
+	}}, workDir); err != nil {
+		t.Fatalf("processUploads rejected a valid upload: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "src", "main.go")); err != nil {
+		t.Fatalf("valid upload was not written into the workspace: %v", err)
+	}
+
+	// Client setuid bit must be stripped.
+	if err := es.processUploads([]domain.FileUpload{{
+		Path:    "tool",
+		Content: []byte("x"),
+		Mode:    0o4755,
+	}}, workDir); err != nil {
+		t.Fatalf("processUploads rejected a valid upload: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(workDir, "tool"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSetuid != 0 {
+		t.Errorf("setuid bit survived upload: mode=%v", info.Mode())
+	}
+}

--- a/internal/joblet/core/job_executor.go
+++ b/internal/joblet/core/job_executor.go
@@ -165,7 +165,8 @@ func (ee *ExecutionEngineV2) executeCICommand(ctx context.Context, opts *StartPr
 	// Process uploads if any
 	if len(opts.Uploads) > 0 {
 		for _, upload := range opts.Uploads {
-			// SECURITY: reject "../" traversal before writing as root (issue #259)
+			// Reject "../" traversal before writing: this runs as root on the
+			// host with no chroot, so an escaping path is an arbitrary host write.
 			fullPath, err := validation.ValidatePathWithinBase(workDir, upload.Path)
 			if err != nil {
 				return nil, err

--- a/internal/joblet/core/job_executor.go
+++ b/internal/joblet/core/job_executor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ehsaniara/joblet/internal/joblet/core/process"
 	"github.com/ehsaniara/joblet/internal/joblet/core/unprivileged"
 	"github.com/ehsaniara/joblet/internal/joblet/core/upload"
+	"github.com/ehsaniara/joblet/internal/joblet/core/validation"
 	"github.com/ehsaniara/joblet/internal/joblet/domain"
 	"github.com/ehsaniara/joblet/internal/joblet/gpu"
 	"github.com/ehsaniara/joblet/internal/joblet/network"
@@ -165,7 +166,7 @@ func (ee *ExecutionEngineV2) executeCICommand(ctx context.Context, opts *StartPr
 	if len(opts.Uploads) > 0 {
 		for _, upload := range opts.Uploads {
 			// SECURITY: reject "../" traversal before writing as root (issue #259)
-			fullPath, err := domain.ResolveUploadPath(workDir, upload.Path)
+			fullPath, err := validation.ValidatePathWithinBase(workDir, upload.Path)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/joblet/core/job_executor.go
+++ b/internal/joblet/core/job_executor.go
@@ -164,16 +164,21 @@ func (ee *ExecutionEngineV2) executeCICommand(ctx context.Context, opts *StartPr
 	// Process uploads if any
 	if len(opts.Uploads) > 0 {
 		for _, upload := range opts.Uploads {
-			fullPath := filepath.Join(workDir, upload.Path)
+			// SECURITY: reject "../" traversal before writing as root (issue #259)
+			fullPath, err := domain.ResolveUploadPath(workDir, upload.Path)
+			if err != nil {
+				return nil, err
+			}
+			mode := domain.SanitizeUploadMode(upload.Mode)
 			if upload.IsDirectory {
-				if err := os.MkdirAll(fullPath, os.FileMode(upload.Mode)); err != nil {
+				if err := os.MkdirAll(fullPath, mode); err != nil {
 					return nil, fmt.Errorf("failed to create directory %s: %w", upload.Path, err)
 				}
 			} else {
 				if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
 					return nil, fmt.Errorf("failed to create parent directory for %s: %w", upload.Path, err)
 				}
-				if err := os.WriteFile(fullPath, upload.Content, os.FileMode(upload.Mode)); err != nil {
+				if err := os.WriteFile(fullPath, upload.Content, mode); err != nil {
 					return nil, fmt.Errorf("failed to write file %s: %w", upload.Path, err)
 				}
 			}

--- a/internal/joblet/core/upload/receiver.go
+++ b/internal/joblet/core/upload/receiver.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/ehsaniara/joblet/internal/joblet/domain"
 	"github.com/ehsaniara/joblet/pkg/logger"
 	"github.com/ehsaniara/joblet/pkg/platform"
 )
@@ -100,7 +101,12 @@ func (r *Receiver) processFilesFromPipe(pipe io.Reader, workspacePath string) er
 			return fmt.Errorf("invalid directory flag: %s", isDirStr)
 		}
 
-		fullPath := filepath.Join(workspacePath, filePath)
+		// SECURITY: the path comes from the pipe header; reject "../" traversal
+		// before writing (this runs as root inside the chroot pre-exec).
+		fullPath, err := domain.ResolveUploadPath(workspacePath, filePath)
+		if err != nil {
+			return err
+		}
 
 		log.Debug("processing file from pipe",
 			"path", filePath,

--- a/internal/joblet/core/upload/receiver.go
+++ b/internal/joblet/core/upload/receiver.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/ehsaniara/joblet/internal/joblet/domain"
+	"github.com/ehsaniara/joblet/internal/joblet/core/validation"
 	"github.com/ehsaniara/joblet/pkg/logger"
 	"github.com/ehsaniara/joblet/pkg/platform"
 )
@@ -103,7 +103,7 @@ func (r *Receiver) processFilesFromPipe(pipe io.Reader, workspacePath string) er
 
 		// SECURITY: the path comes from the pipe header; reject "../" traversal
 		// before writing (this runs as root inside the chroot pre-exec).
-		fullPath, err := domain.ResolveUploadPath(workspacePath, filePath)
+		fullPath, err := validation.ValidatePathWithinBase(workspacePath, filePath)
 		if err != nil {
 			return err
 		}

--- a/internal/joblet/domain/file_upload.go
+++ b/internal/joblet/domain/file_upload.go
@@ -66,26 +66,6 @@ func (us *UploadSession) OptimizeForMemory(memoryLimitMB int32) {
 	}
 }
 
-// ResolveUploadPath joins baseDir with a client-supplied relative upload path
-// and guarantees the result stays within baseDir. Every filesystem write
-// driven by a client-controlled upload path MUST go through this - the join
-// alone (filepath.Join) silently resolves "../" and escapes the workspace,
-// and these writes happen as root on the host before any chroot exists.
-func ResolveUploadPath(baseDir, uploadPath string) (string, error) {
-	if uploadPath == "" {
-		return "", fmt.Errorf("empty upload path")
-	}
-	if filepath.IsAbs(uploadPath) {
-		return "", fmt.Errorf("absolute upload path not allowed: %q", uploadPath)
-	}
-	full := filepath.Join(baseDir, uploadPath)
-	rel, err := filepath.Rel(baseDir, full)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return "", fmt.Errorf("upload path escapes workspace: %q", uploadPath)
-	}
-	return full, nil
-}
-
 // SanitizeUploadMode masks a client-supplied file mode to permission bits
 // only, stripping setuid/setgid/sticky so a client cannot request a setuid
 // file be written as root.

--- a/internal/joblet/domain/file_upload.go
+++ b/internal/joblet/domain/file_upload.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -63,6 +64,33 @@ func (us *UploadSession) OptimizeForMemory(memoryLimitMB int32) {
 	if us.ChunkSize < 4096 {
 		us.ChunkSize = 4096
 	}
+}
+
+// ResolveUploadPath joins baseDir with a client-supplied relative upload path
+// and guarantees the result stays within baseDir. Every filesystem write
+// driven by a client-controlled upload path MUST go through this - the join
+// alone (filepath.Join) silently resolves "../" and escapes the workspace,
+// and these writes happen as root on the host before any chroot exists.
+func ResolveUploadPath(baseDir, uploadPath string) (string, error) {
+	if uploadPath == "" {
+		return "", fmt.Errorf("empty upload path")
+	}
+	if filepath.IsAbs(uploadPath) {
+		return "", fmt.Errorf("absolute upload path not allowed: %q", uploadPath)
+	}
+	full := filepath.Join(baseDir, uploadPath)
+	rel, err := filepath.Rel(baseDir, full)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("upload path escapes workspace: %q", uploadPath)
+	}
+	return full, nil
+}
+
+// SanitizeUploadMode masks a client-supplied file mode to permission bits
+// only, stripping setuid/setgid/sticky so a client cannot request a setuid
+// file be written as root.
+func SanitizeUploadMode(mode uint32) os.FileMode {
+	return os.FileMode(mode) & 0o777
 }
 
 // validateFilePath ensures file paths are safe

--- a/internal/joblet/domain/file_upload_test.go
+++ b/internal/joblet/domain/file_upload_test.go
@@ -1,0 +1,68 @@
+package domain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveUploadPath(t *testing.T) {
+	base := "/opt/joblet/jobs/abc/work"
+
+	// Paths that must be rejected as workspace escapes (issue #1 path traversal)
+	rejected := []string{
+		"../../../../etc/cron.d/x",
+		"../../../../../opt/joblet/bin/joblet",
+		"../outside",
+		"/etc/passwd",
+		"a/../../../etc/x",
+		"",
+	}
+	for _, p := range rejected {
+		if got, err := ResolveUploadPath(base, p); err == nil {
+			t.Errorf("ResolveUploadPath(%q) = %q, want error (escapes workspace)", p, got)
+		}
+	}
+
+	// Legitimate in-workspace paths must resolve within base
+	allowed := map[string]string{
+		"script.py":        filepath.Join(base, "script.py"),
+		"src/main.go":      filepath.Join(base, "src/main.go"),
+		"a/../b/file.txt":  filepath.Join(base, "b/file.txt"), // cleans to within base
+		"./data.csv":       filepath.Join(base, "data.csv"),
+		"nested/deep/x.sh": filepath.Join(base, "nested/deep/x.sh"),
+	}
+	for in, want := range allowed {
+		got, err := ResolveUploadPath(base, in)
+		if err != nil {
+			t.Errorf("ResolveUploadPath(%q) unexpected error: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("ResolveUploadPath(%q) = %q, want %q", in, got, want)
+		}
+		// Invariant: the result never escapes base
+		rel, err := filepath.Rel(base, got)
+		if err != nil || rel == ".." || len(rel) >= 2 && rel[:2] == ".." {
+			t.Errorf("ResolveUploadPath(%q) = %q escaped base %q (rel=%q)", in, got, base, rel)
+		}
+	}
+}
+
+func TestSanitizeUploadMode(t *testing.T) {
+	// setuid (04000), setgid (02000), sticky (01000) must be stripped
+	cases := map[uint32]os.FileMode{
+		0o755:      0o755,
+		0o644:      0o644,
+		0o4755:     0o755, // setuid stripped
+		0o2755:     0o755, // setgid stripped
+		0o1777:     0o777, // sticky stripped
+		0o104755:   0o755, // file-type + setuid bits stripped
+		0xFFFFFFFF: 0o777, // garbage clamps to perm bits
+	}
+	for in, want := range cases {
+		if got := SanitizeUploadMode(in); got != want {
+			t.Errorf("SanitizeUploadMode(%o) = %o, want %o", in, got, want)
+		}
+	}
+}

--- a/internal/joblet/domain/file_upload_test.go
+++ b/internal/joblet/domain/file_upload_test.go
@@ -2,52 +2,8 @@ package domain
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 )
-
-func TestResolveUploadPath(t *testing.T) {
-	base := "/opt/joblet/jobs/abc/work"
-
-	// Paths that must be rejected as workspace escapes (issue #1 path traversal)
-	rejected := []string{
-		"../../../../etc/cron.d/x",
-		"../../../../../opt/joblet/bin/joblet",
-		"../outside",
-		"/etc/passwd",
-		"a/../../../etc/x",
-		"",
-	}
-	for _, p := range rejected {
-		if got, err := ResolveUploadPath(base, p); err == nil {
-			t.Errorf("ResolveUploadPath(%q) = %q, want error (escapes workspace)", p, got)
-		}
-	}
-
-	// Legitimate in-workspace paths must resolve within base
-	allowed := map[string]string{
-		"script.py":        filepath.Join(base, "script.py"),
-		"src/main.go":      filepath.Join(base, "src/main.go"),
-		"a/../b/file.txt":  filepath.Join(base, "b/file.txt"), // cleans to within base
-		"./data.csv":       filepath.Join(base, "data.csv"),
-		"nested/deep/x.sh": filepath.Join(base, "nested/deep/x.sh"),
-	}
-	for in, want := range allowed {
-		got, err := ResolveUploadPath(base, in)
-		if err != nil {
-			t.Errorf("ResolveUploadPath(%q) unexpected error: %v", in, err)
-			continue
-		}
-		if got != want {
-			t.Errorf("ResolveUploadPath(%q) = %q, want %q", in, got, want)
-		}
-		// Invariant: the result never escapes base
-		rel, err := filepath.Rel(base, got)
-		if err != nil || rel == ".." || len(rel) >= 2 && rel[:2] == ".." {
-			t.Errorf("ResolveUploadPath(%q) = %q escaped base %q (rel=%q)", in, got, base, rel)
-		}
-	}
-}
 
 func TestSanitizeUploadMode(t *testing.T) {
 	// setuid (04000), setgid (02000), sticky (01000) must be stripped

--- a/internal/joblet/server/job_service.go
+++ b/internal/joblet/server/job_service.go
@@ -172,10 +172,11 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 			"totalSize", totalSize)
 	}
 
-	// SECURITY (issue #258): the isolation mode is a server-side decision and
-	// must never be derived from client input. Jobs submitted through RunJob
-	// always use standard (unprivileged) isolation; privileged runtime builds
-	// run through the dedicated, separately-authorized BuildRuntime RPC.
+	// The isolation mode is a server-side decision and must never be derived
+	// from client input: runtime-build jobs skip the privilege drop and network
+	// isolation, so a client that could pick the mode could run as host root.
+	// RunJob always produces standard (unprivileged) jobs; privileged runtime
+	// builds go through the dedicated, separately-authorized BuildRuntime RPC.
 	jobType := domain.JobTypeStandard
 
 	// Strip reserved control variables so a client cannot inject JOB_TYPE (or

--- a/internal/joblet/server/job_service_test.go
+++ b/internal/joblet/server/job_service_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ehsaniara/joblet/pkg/logger"
 )
 
-// TestConvertToJobRequest_IgnoresClientJobTypeEnv is a regression test for
-// the runtime-build privilege-escalation bug (issue #258). The server must
-// never derive the JobType from client-supplied environment variables;
-// RunJob always produces standard-isolation jobs.
+// TestConvertToJobRequest_IgnoresClientJobTypeEnv guards the rule that the
+// server never derives JobType from client-supplied environment variables:
+// a client-set JOB_TYPE=runtime-build would otherwise skip the privilege drop
+// and run as host root. RunJob must always produce standard-isolation jobs.
 func TestConvertToJobRequest_IgnoresClientJobTypeEnv(t *testing.T) {
 	tests := []struct {
 		name string

--- a/tests/e2e/tests/05_volume_test.sh
+++ b/tests/e2e/tests/05_volume_test.sh
@@ -63,19 +63,22 @@ verify_remote_directory() {
 test_upload_directory() {
     # Upload a nested directory - exercises the relative-path (subdir) upload
     # flow end to end, which routes through the server's path-containment
-    # check (issue #1). Verifies nested files land at the right workspace path.
+    # check, and verifies nested files land at the right workspace path.
     local test_dir="/tmp/test_uploaddir_$$"
     mkdir -p "$test_dir/sub"
     echo "$TEST_DATA" > "$test_dir/sub/nested.txt"
 
     echo -e "    ${BLUE}Testing nested directory upload to $TEST_HOST${NC}"
 
+    # rnx uploads a directory's CONTENTS relative to the dir, so sub/nested.txt
+    # lands at /work/sub/nested.txt (no basename prefix). This exercises the
+    # server-side relative-path containment check for a subdir path.
     local job_output=$("$RNX_BINARY" job run \
         --upload="$test_dir" \
         sh -c "
-if [ -f '/work/$(basename "$test_dir")/sub/nested.txt' ]; then
+if [ -f '/work/sub/nested.txt' ]; then
     echo 'NESTED_FOUND'
-    cat '/work/$(basename "$test_dir")/sub/nested.txt' | sed 's/^/NESTED:/'
+    cat '/work/sub/nested.txt' | sed 's/^/NESTED:/'
 else
     echo 'NESTED_NOT_FOUND'
     find /work -type f

--- a/tests/e2e/tests/05_volume_test.sh
+++ b/tests/e2e/tests/05_volume_test.sh
@@ -60,6 +60,40 @@ verify_remote_directory() {
 # Test Functions
 # ============================================
 
+test_upload_directory() {
+    # Upload a nested directory - exercises the relative-path (subdir) upload
+    # flow end to end, which routes through the server's path-containment
+    # check (issue #1). Verifies nested files land at the right workspace path.
+    local test_dir="/tmp/test_uploaddir_$$"
+    mkdir -p "$test_dir/sub"
+    echo "$TEST_DATA" > "$test_dir/sub/nested.txt"
+
+    echo -e "    ${BLUE}Testing nested directory upload to $TEST_HOST${NC}"
+
+    local job_output=$("$RNX_BINARY" job run \
+        --upload="$test_dir" \
+        sh -c "
+if [ -f '/work/$(basename "$test_dir")/sub/nested.txt' ]; then
+    echo 'NESTED_FOUND'
+    cat '/work/$(basename "$test_dir")/sub/nested.txt' | sed 's/^/NESTED:/'
+else
+    echo 'NESTED_NOT_FOUND'
+    find /work -type f
+fi
+" 2>&1)
+
+    local job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+    local logs=$(get_job_logs "$job_id" 5)
+
+    rm -rf "$test_dir"
+    if assert_contains "$logs" "NESTED:$TEST_DATA" "Nested upload should land at its subdir path"; then
+        echo -e "    ${GREEN}✓ Nested directory upload preserved subdir structure${NC}"
+        return 0
+    else
+        return 1
+    fi
+}
+
 test_upload_file() {
     # Test uploading a file to a job with remote host verification
     local test_file="/tmp/test_upload_$$.txt"
@@ -367,6 +401,7 @@ main() {
     # Run tests
     test_section "File Transfer"
     run_test "Upload file to job" test_upload_file
+    run_test "Upload nested directory to job" test_upload_directory
     run_test "Download results from job" test_download_result
     
     test_section "Volume Operations"


### PR DESCRIPTION
  A client-supplied upload path was written to the host filesystem with no containment check, as **root, before any chroot/namespace exists**. A crafted gRPC request with an upload path like `../../../../etc/cron.d/x` (or `../../opt/joblet/bin/joblet`) escaped the job workspace and wrote arbitrary content anywhere on the host — a full host compromise reachable by any client holding a `developer`-or-higher certificate.                                                                                                                                                                  
                                                                                                                                                                                                                
  The stock `rnx` CLI sanitizes upload paths client-side (`filepath.Base` / `filepath.Rel`), which is why this never surfaced in normal use — but that is not a security control. The server must validate its own inputs.  

- Route **every** upload write site through the existing, already-used `validation.ValidatePathWithinBase`, which rejects absolute paths and any  result that escapes the workspace:                                                                                                                                                                          
    - `execution/environment_service.go` — the live `RunJob` path                                                                                                                                               
    - `core/job_executor.go` — the CI-mode path                                                                                                                                                                 
    - `core/upload/receiver.go` — the init-side pipe path (the init-mode JSON path already used it)                                                                                                                                                                   
- Mask client-supplied file modes to permission bits only (`domain.SanitizeUploadMode`), stripping setuid/setgid/sticky so a client cannot request a setuid file be written as root.                                                                                                                                                            
- Removed a duplicate path validator so all four upload paths share one implementation.