### PR TITLE
fix: reject reserved control env vars from client job requests

### DIFF
--- a/cmd/joblet/main.go
+++ b/cmd/joblet/main.go
@@ -26,6 +26,12 @@ func main() {
 		cfg.Server.Mode = "init"
 		path = config.BuiltInDefaultsPath
 	} else {
+		// Defense in depth: a process holding job-control vars but not running
+		// in init mode means the mode was tampered with; never start the daemon.
+		if config.LooksLikeJobProcess() {
+			log.Fatalf("Refusing to start server: job-control environment is present but JOBLET_MODE is not 'init'. The execution mode may have been tampered with.")
+		}
+
 		var err error
 		cfg, path, err = config.LoadConfig()
 		if err != nil {

--- a/internal/joblet/core/execution/env_order_test.go
+++ b/internal/joblet/core/execution/env_order_test.go
@@ -1,0 +1,45 @@
+package execution
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehsaniara/joblet/internal/joblet/domain"
+	"github.com/ehsaniara/joblet/pkg/logger"
+	"github.com/ehsaniara/joblet/pkg/platform"
+)
+
+// Defense in depth for the reserved-namespace rule: even if a job somehow
+// carried a reserved key in its client environment, the trusted control block
+// is appended last so it wins the os/exec last-duplicate race.
+func TestBuildEnvironment_TrustedControlVarsWin(t *testing.T) {
+	es := &EnvironmentService{
+		platform: platform.NewPlatform(),
+		logger:   logger.New(),
+	}
+	job := &domain.Job{
+		Uuid:              "job-123",
+		Command:           "/bin/true",
+		Environment:       map[string]string{"JOBLET_MODE": "server"},
+		SecretEnvironment: map[string]string{"JOB_ID": "attacker"},
+	}
+
+	env := es.BuildEnvironment(job, "execute")
+
+	// os/exec keeps the LAST occurrence of a key, so assert the last wins.
+	var lastMode, lastJobID string
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "JOBLET_MODE=") {
+			lastMode = kv
+		}
+		if strings.HasPrefix(kv, "JOB_ID=") {
+			lastJobID = kv
+		}
+	}
+	if lastMode != "JOBLET_MODE=init" {
+		t.Errorf("last JOBLET_MODE = %q; want JOBLET_MODE=init (trusted must win)", lastMode)
+	}
+	if lastJobID != "JOB_ID=job-123" {
+		t.Errorf("last JOB_ID = %q; want JOB_ID=job-123 (trusted must win)", lastJobID)
+	}
+}

--- a/internal/joblet/core/execution/environment_service.go
+++ b/internal/joblet/core/execution/environment_service.go
@@ -82,9 +82,22 @@ func (es *EnvironmentService) BuildEnvironment(job *domain.Job, phase string) []
 		jobEnv = append(jobEnv, fmt.Sprintf("JOB_RUNTIME=%s", job.Runtime))
 	}
 
-	// Combine all environment variables
-	env := append(baseEnv, jobEnv...)
+	// Assemble so joblet's own control variables always win. Jobs launch via
+	// os/exec, which keeps the last duplicate of a key, so the trusted jobEnv
+	// block is appended LAST - after client, runtime, and GPU env - and cannot
+	// be overridden by anything earlier.
+	env := baseEnv
 
+	// Client-supplied environment (lowest priority; already validated to be
+	// outside joblet's reserved namespace at the request boundary).
+	for key, value := range job.Environment {
+		env = append(env, fmt.Sprintf("%s=%s", key, value))
+	}
+	for key, value := range job.SecretEnvironment {
+		env = append(env, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	// Runtime (admin-authored runtime.yml) and GPU environment.
 	if job.Runtime != "" {
 		runtimeEnv, err := es.getRuntimeEnvironment(job.Runtime)
 		if err != nil {
@@ -93,20 +106,12 @@ func (es *EnvironmentService) BuildEnvironment(job *domain.Job, phase string) []
 			env = append(env, runtimeEnv...)
 		}
 	}
-
-	// Add GPU environment variables if GPUs are allocated
 	if job.HasGPURequirement() && job.IsGPUAllocated() {
-		gpuEnv := es.buildGPUEnvironment(job)
-		env = append(env, gpuEnv...)
+		env = append(env, es.buildGPUEnvironment(job)...)
 	}
 
-	for key, value := range job.Environment {
-		env = append(env, fmt.Sprintf("%s=%s", key, value))
-	}
-
-	for key, value := range job.SecretEnvironment {
-		env = append(env, fmt.Sprintf("%s=%s", key, value))
-	}
+	// Trusted control block last so it wins the os/exec last-duplicate race.
+	env = append(env, jobEnv...)
 
 	return env
 }

--- a/internal/joblet/server/job_service.go
+++ b/internal/joblet/server/job_service.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	pb "github.com/ehsaniara/joblet-proto/v2/gen"
 	"github.com/ehsaniara/joblet/internal/joblet/adapters"
 	auth2 "github.com/ehsaniara/joblet/internal/joblet/auth"
 	"github.com/ehsaniara/joblet/internal/joblet/core/interfaces"
+	"github.com/ehsaniara/joblet/internal/joblet/core/validation"
 	"github.com/ehsaniara/joblet/internal/joblet/domain"
 	"github.com/ehsaniara/joblet/internal/joblet/gpu"
 	"github.com/ehsaniara/joblet/internal/joblet/mappers"
@@ -179,11 +181,15 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 	// builds go through the dedicated, separately-authorized BuildRuntime RPC.
 	jobType := domain.JobTypeStandard
 
-	// Strip reserved control variables so a client cannot inject JOB_TYPE (or
-	// other trusted JOB_* vars) into the job process environment, which the
-	// in-namespace init reads to decide isolation behavior (see
-	// internal/modes/jobexec and internal/modes/isolation).
-	environment := sanitizeClientEnvironment(req.Environment)
+	// Reject any client env var in joblet's reserved namespace (both the plain
+	// and secret maps) so a client cannot inject the control variables the
+	// in-namespace init trusts to decide execution mode and isolation.
+	if err := validateClientEnvironment(req.Environment); err != nil {
+		return nil, err
+	}
+	if err := validateClientEnvironment(req.SecretEnvironment); err != nil {
+		return nil, err
+	}
 
 	jobRequest := &interfaces.StartJobRequest{
 		Command: req.Command,
@@ -199,7 +205,7 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 		Network:           network,
 		Volumes:           req.Volumes,
 		Runtime:           req.Runtime,
-		Environment:       environment,
+		Environment:       req.Environment,
 		SecretEnvironment: req.SecretEnvironment,
 		JobType:           jobType,
 		GPUCount:          req.GpuCount,
@@ -214,28 +220,40 @@ func (s *JobServiceServer) convertToJobRequest(req *pb.RunJobRequest) (*interfac
 	return jobRequest, nil
 }
 
-// reservedEnvKeys are environment variables the joblet runtime sets and the
-// isolation layer trusts; clients must not be able to supply them through a
-// job request.
-var reservedEnvKeys = map[string]bool{
-	"JOB_TYPE": true,
+// reservedEnvPrefixes and reservedEnvExact name the environment namespace the
+// joblet runtime controls. The in-namespace init and the isolation layer read
+// these to decide the execution mode, filesystem paths, and runtime/volume
+// mounts, so a client that could set one could flip the job process into server
+// mode (JOBLET_MODE - runs the daemon as un-chrooted root with the private-key
+// config) or bind arbitrary host paths into the sandbox. Jobs launch via
+// os/exec, which keeps the LAST duplicate of a key, so a client value appended
+// after the trusted one would win - hence these are rejected at the request
+// boundary, not merely stripped.
+var reservedEnvPrefixes = []string{"JOB_", "JOBLET_"}
+
+var reservedEnvExact = map[string]bool{
+	"RUNTIME_MANAGER_PATH": true,
+	"NETWORK_READY_FILE":   true,
 }
 
-// sanitizeClientEnvironment returns a copy of the client-supplied environment
-// with reserved control variables removed. A nil or empty input is returned
-// unchanged.
-func sanitizeClientEnvironment(env map[string]string) map[string]string {
-	if len(env) == 0 {
-		return env
-	}
-	sanitized := make(map[string]string, len(env))
+// validateClientEnvironment rejects client-supplied environment variables that
+// collide with the reserved joblet namespace or are malformed. It is applied to
+// both the plain and secret environment maps.
+func validateClientEnvironment(env map[string]string) error {
 	for k, v := range env {
-		if reservedEnvKeys[k] {
-			continue
+		if err := validation.ValidateEnvironmentVariable(k, v); err != nil {
+			return err
 		}
-		sanitized[k] = v
+		if reservedEnvExact[k] {
+			return fmt.Errorf("environment variable %q is reserved by joblet and cannot be set by a client", k)
+		}
+		for _, p := range reservedEnvPrefixes {
+			if strings.HasPrefix(k, p) {
+				return fmt.Errorf("environment variable %q uses the reserved %q namespace and cannot be set by a client", k, p)
+			}
+		}
 	}
-	return sanitized
+	return nil
 }
 
 func (s *JobServiceServer) validateJobRequest(req *interfaces.StartJobRequest) error {

--- a/internal/joblet/server/job_service_test.go
+++ b/internal/joblet/server/job_service_test.go
@@ -12,34 +12,62 @@ import (
 // server never derives JobType from client-supplied environment variables:
 // a client-set JOB_TYPE=runtime-build would otherwise skip the privilege drop
 // and run as host root. RunJob must always produce standard-isolation jobs.
-func TestConvertToJobRequest_IgnoresClientJobTypeEnv(t *testing.T) {
-	tests := []struct {
-		name string
-		env  map[string]string
-	}{
-		{"runtime-build", map[string]string{"JOB_TYPE": "runtime-build"}},
-		{"mixed case", map[string]string{"JOB_TYPE": "Runtime-Build"}},
-		{"runtime-build with siblings", map[string]string{"JOB_TYPE": "runtime-build", "FOO": "bar"}},
-		{"empty env", map[string]string{}},
-		{"nil env", nil},
-	}
-
+// A client must not be able to supply variables in joblet's reserved namespace:
+// the in-namespace init trusts them to decide execution mode and isolation, and
+// os/exec's last-duplicate-wins would let a client value override the trusted
+// one. Reserved keys are rejected at the request boundary, in both the plain and
+// secret environment maps.
+func TestConvertToJobRequest_RejectsReservedEnv(t *testing.T) {
 	s := &JobServiceServer{logger: logger.New().WithField("test", "true")}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			req := &pb.RunJobRequest{
-				Command:     "/bin/true",
-				Environment: tc.env,
-			}
+	reserved := []struct {
+		name string
+		key  string
+	}{
+		{"mode flip", "JOBLET_MODE"},
+		{"job type", "JOB_TYPE"},
+		{"forwarded fs path", "JOB_FS_TMP_DIR"},
+		{"runtime manager path", "RUNTIME_MANAGER_PATH"},
+		{"network ready file", "NETWORK_READY_FILE"},
+	}
 
-			got, err := s.convertToJobRequest(req)
+	for _, r := range reserved {
+		t.Run("plain/"+r.name, func(t *testing.T) {
+			_, err := s.convertToJobRequest(&pb.RunJobRequest{
+				Command:     "/bin/true",
+				Environment: map[string]string{r.key: "x"},
+			})
+			if err == nil {
+				t.Fatalf("reserved key %q accepted in Environment; want rejection", r.key)
+			}
+		})
+		t.Run("secret/"+r.name, func(t *testing.T) {
+			_, err := s.convertToJobRequest(&pb.RunJobRequest{
+				Command:           "/bin/true",
+				SecretEnvironment: map[string]string{r.key: "x"},
+			})
+			if err == nil {
+				t.Fatalf("reserved key %q accepted in SecretEnvironment; want rejection", r.key)
+			}
+		})
+	}
+
+	// Legitimate client env is accepted, and jobs are always standard isolation.
+	for _, name := range []string{"nil", "empty", "legit"} {
+		t.Run("allowed/"+name, func(t *testing.T) {
+			env := map[string]string{}
+			switch name {
+			case "nil":
+				env = nil
+			case "legit":
+				env = map[string]string{"FOO": "bar", "MY_VAR": "value"}
+			}
+			got, err := s.convertToJobRequest(&pb.RunJobRequest{Command: "/bin/true", Environment: env})
 			if err != nil {
-				t.Fatalf("convertToJobRequest returned error: %v", err)
+				t.Fatalf("convertToJobRequest rejected legitimate env: %v", err)
 			}
 			if got.JobType != domain.JobTypeStandard {
-				t.Fatalf("JobType = %q; want %q (client must not influence isolation mode)",
-					got.JobType, domain.JobTypeStandard)
+				t.Fatalf("JobType = %q; want %q", got.JobType, domain.JobTypeStandard)
 			}
 		})
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -547,6 +547,16 @@ func loadFromFile(config *Config) (string, error) {
 // error; init mode inside job containers tolerates it.
 const BuiltInDefaultsPath = "built-in defaults (no config file found)"
 
+// LooksLikeJobProcess reports whether the current environment carries the
+// job-control variables the server sets only when launching a job's init
+// process. Such a process must run in init mode; if it instead reaches the
+// server path, the execution mode was tampered with (e.g. a client-injected
+// JOBLET_MODE that won the os/exec last-duplicate race) and it must refuse to
+// start the daemon rather than run it as un-chrooted root inside a job.
+func LooksLikeJobProcess() bool {
+	return os.Getenv("JOB_ID") != "" || os.Getenv("JOB_CGROUP_HOST_PATH") != ""
+}
+
 // InitConfig returns the configuration for the job init process: built-in
 // defaults overridden by the effective values the server loaded at startup
 // and forwarded through the job environment (JOB_FS_*). Init never reads

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -915,3 +915,22 @@ func TestInitConfig(t *testing.T) {
 		}
 	})
 }
+
+func TestLooksLikeJobProcess(t *testing.T) {
+	for _, k := range []string{"JOB_ID", "JOB_CGROUP_HOST_PATH"} {
+		t.Run("set/"+k, func(t *testing.T) {
+			os.Setenv(k, "x")
+			defer os.Unsetenv(k)
+			if !LooksLikeJobProcess() {
+				t.Errorf("LooksLikeJobProcess() = false with %s set; want true", k)
+			}
+		})
+	}
+	t.Run("none set", func(t *testing.T) {
+		os.Unsetenv("JOB_ID")
+		os.Unsetenv("JOB_CGROUP_HOST_PATH")
+		if LooksLikeJobProcess() {
+			t.Error("LooksLikeJobProcess() = true with no job vars; want false")
+		}
+	})
+}

--- a/tests/e2e/tests/01_isolation_test.sh
+++ b/tests/e2e/tests/01_isolation_test.sh
@@ -487,6 +487,35 @@ test_uts_namespace() {
 
 run_test_check "UTS namespace isolation" test_uts_namespace
 
+echo -e "\n${YELLOW}▶ 9. Reserved Environment Rejection${NC}"
+echo -e "${BLUE}─────────────────────────────────────────────────────────────────${NC}"
+
+test_reserved_env_rejected() {
+    # A client must not be able to set joblet's control vars: JOBLET_MODE=server
+    # would flip the job process into the daemon (un-chrooted root). The server
+    # must reject the request, not run the job.
+    local out=$("$RNX_BINARY" job run --env JOBLET_MODE=server echo should-not-run 2>&1)
+    local id=$(echo "$out" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$id" ]] && echo "$out" | grep -qiE "reserved|cannot be set"; then
+        echo "    Reserved env JOBLET_MODE rejected at submission"
+    else
+        echo "    Reserved env was NOT rejected (id=$id): $out"
+        return 1
+    fi
+
+    # Same for the secret env map, and for the JOB_* namespace.
+    local out2=$("$RNX_BINARY" job run --secret-env JOB_ID=attacker echo x 2>&1)
+    if echo "$out2" | grep -qiE "reserved|cannot be set" && ! echo "$out2" | grep -q "^ID:"; then
+        echo "    Reserved secret env JOB_ID rejected at submission"
+        return 0
+    fi
+    echo "    Reserved secret env was NOT rejected: $out2"
+    return 1
+}
+
+run_test_check "Reserved environment variables rejected" test_reserved_env_rejected
+
 # ============================================
 # SUMMARY
 # ============================================


### PR DESCRIPTION
Reject any client-supplied env var in joblet's reserved namespace (JOB_*, JOBLET_*, RUNTIME_MANAGER_PATH, NETWORK_READY_FILE) in both the plain and secret environment maps, so a client cannot inject JOBLET_MODE=server (which would run the daemon as un-chrooted root inside a job) or other control vars the in-namespace init trusts. Also assemble the job environment so trusted  control vars win the os/exec last-duplicate race, and refuse to start the server when job-control vars are present but JOBLET_MODE is not init.