### PR TITLE
fix: forward runtime allowed-mounts and base path to job init

### DIFF
--- a/internal/joblet/core/environment/builder.go
+++ b/internal/joblet/core/environment/builder.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +38,24 @@ func ForwardFilesystemEnv(fs *config.FilesystemConfig) []string {
 		fmt.Sprintf("JOB_FS_BASE_DIR=%s", fs.BaseDir),
 		fmt.Sprintf("JOB_FS_TMP_DIR=%s", fs.TmpDir),
 	}
+}
+
+// ForwardRuntimeEnv renders the server's effective runtime settings that the
+// job init process consumes - the runtime base path and the list of host dirs
+// allowed to be mounted into the sandbox - as JOB_RT_* environment variables.
+// Init cannot read the server config file, so without these it falls back to
+// the truncated built-in AllowedMounts and jobs lose the mounts the operator's
+// distro runtime config provides (e.g. /usr/sbin, /usr/lib, /etc/ssl, the TLS
+// trust store). AllowedMounts is joined with the OS path-list separator.
+func ForwardRuntimeEnv(rt *config.RuntimeConfig) []string {
+	env := []string{
+		fmt.Sprintf("JOB_RT_BASE_PATH=%s", rt.BasePath),
+	}
+	if len(rt.AllowedMounts) > 0 {
+		env = append(env, fmt.Sprintf("JOB_RT_ALLOWED_MOUNTS=%s",
+			strings.Join(rt.AllowedMounts, string(os.PathListSeparator))))
+	}
+	return env
 }
 
 // Builder handles environment variable construction for job execution
@@ -111,6 +130,7 @@ func (b *Builder) buildCoreEnvironment(job *domain.Job, execPath string) []strin
 	// loaded config values rather than assuming built-in defaults
 	if b.config != nil {
 		env = append(env, ForwardFilesystemEnv(&b.config.Filesystem)...)
+		env = append(env, ForwardRuntimeEnv(&b.config.Runtime)...)
 	}
 
 	if !job.Limits.CPUCores.IsEmpty() {

--- a/internal/joblet/core/environment/forward_test.go
+++ b/internal/joblet/core/environment/forward_test.go
@@ -1,0 +1,32 @@
+package environment
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehsaniara/joblet/pkg/config"
+)
+
+func TestForwardRuntimeEnv(t *testing.T) {
+	rt := &config.RuntimeConfig{
+		BasePath:      "/opt/joblet/runtimes",
+		AllowedMounts: []string{"/usr/bin", "/usr/sbin", "/etc/ssl"},
+	}
+	env := ForwardRuntimeEnv(rt)
+
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, "JOB_RT_BASE_PATH=/opt/joblet/runtimes") {
+		t.Errorf("missing JOB_RT_BASE_PATH in %v", env)
+	}
+	if !strings.Contains(joined, "JOB_RT_ALLOWED_MOUNTS=/usr/bin:/usr/sbin:/etc/ssl") {
+		t.Errorf("AllowedMounts not path-list joined in %v", env)
+	}
+
+	// Empty AllowedMounts must not emit the var (init keeps built-in default).
+	env2 := ForwardRuntimeEnv(&config.RuntimeConfig{BasePath: "/x"})
+	for _, kv := range env2 {
+		if strings.HasPrefix(kv, "JOB_RT_ALLOWED_MOUNTS=") {
+			t.Errorf("empty AllowedMounts should not be forwarded, got %q", kv)
+		}
+	}
+}

--- a/internal/joblet/core/execution/environment_service.go
+++ b/internal/joblet/core/execution/environment_service.go
@@ -61,6 +61,7 @@ func (es *EnvironmentService) BuildEnvironment(job *domain.Job, phase string) []
 
 	if es.config != nil {
 		jobEnv = append(jobEnv, environment.ForwardFilesystemEnv(&es.config.Filesystem)...)
+		jobEnv = append(jobEnv, environment.ForwardRuntimeEnv(&es.config.Runtime)...)
 	}
 
 	for i, arg := range job.Args {

--- a/internal/joblet/core/process/manager.go
+++ b/internal/joblet/core/process/manager.go
@@ -505,6 +505,7 @@ func (m *Manager) BuildJobEnvironment(job *domain.Job, execPath string) []string
 
 	if m.config != nil {
 		jobEnv = append(jobEnv, environment.ForwardFilesystemEnv(&m.config.Filesystem)...)
+		jobEnv = append(jobEnv, environment.ForwardRuntimeEnv(&m.config.Runtime)...)
 	}
 
 	return append(baseEnv, jobEnv...)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -573,6 +573,12 @@ func InitConfig() *Config {
 	if v := os.Getenv("JOB_FS_TMP_DIR"); v != "" {
 		cfg.Filesystem.TmpDir = v
 	}
+	if v := os.Getenv("JOB_RT_BASE_PATH"); v != "" {
+		cfg.Runtime.BasePath = v
+	}
+	if v := os.Getenv("JOB_RT_ALLOWED_MOUNTS"); v != "" {
+		cfg.Runtime.AllowedMounts = filepath.SplitList(v)
+	}
 	return &cfg
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -903,6 +904,13 @@ func TestInitConfig(t *testing.T) {
 			os.Unsetenv("JOB_FS_TMP_DIR")
 		}()
 
+		os.Setenv("JOB_RT_BASE_PATH", "/custom-runtimes")
+		os.Setenv("JOB_RT_ALLOWED_MOUNTS", "/usr/bin:/usr/sbin:/etc/ssl")
+		defer func() {
+			os.Unsetenv("JOB_RT_BASE_PATH")
+			os.Unsetenv("JOB_RT_ALLOWED_MOUNTS")
+		}()
+
 		cfg := InitConfig()
 		if cfg.Filesystem.WorkspaceDir != "/custom-work" {
 			t.Errorf("expected forwarded workspace dir, got %q", cfg.Filesystem.WorkspaceDir)
@@ -912,6 +920,13 @@ func TestInitConfig(t *testing.T) {
 		}
 		if cfg.Filesystem.TmpDir != "/custom-tmp/{JOB_ID}" {
 			t.Errorf("expected forwarded tmp dir, got %q", cfg.Filesystem.TmpDir)
+		}
+		if cfg.Runtime.BasePath != "/custom-runtimes" {
+			t.Errorf("expected forwarded runtime base path, got %q", cfg.Runtime.BasePath)
+		}
+		wantMounts := []string{"/usr/bin", "/usr/sbin", "/etc/ssl"}
+		if strings.Join(cfg.Runtime.AllowedMounts, ":") != strings.Join(wantMounts, ":") {
+			t.Errorf("expected forwarded allowed mounts %v, got %v", wantMounts, cfg.Runtime.AllowedMounts)
 		}
 	})
 }

--- a/tests/e2e/tests/01_isolation_test.sh
+++ b/tests/e2e/tests/01_isolation_test.sh
@@ -516,6 +516,26 @@ test_reserved_env_rejected() {
 
 run_test_check "Reserved environment variables rejected" test_reserved_env_rejected
 
+echo -e "\n${YELLOW}▶ 10. Runtime Allowed Mounts${NC}"
+echo -e "${BLUE}─────────────────────────────────────────────────────────────────${NC}"
+
+test_runtime_allowed_mounts() {
+    # The server's installed per-distro runtime config lists the host dirs
+    # mounted into the sandbox, including the TLS trust store. These must reach
+    # the job init via forwarding rather than falling back to the truncated
+    # built-in set (which lacks /usr/sbin and /etc/ssl).
+    local out=$(run_remote_job "ls -d /usr/sbin /etc/ssl >/dev/null 2>&1 && echo MOUNTS_PRESENT || echo MOUNTS_MISSING")
+
+    if echo "$out" | grep -q "MOUNTS_PRESENT"; then
+        echo "    Distro allowed_mounts present in sandbox (/usr/sbin, /etc/ssl)"
+        return 0
+    fi
+    echo "    Distro allowed_mounts missing from sandbox (built-in fallback?): $out"
+    return 1
+}
+
+run_test_check "Runtime allowed mounts forwarded to sandbox" test_runtime_allowed_mounts
+
 # ============================================
 # SUMMARY
 # ============================================


### PR DESCRIPTION
 Job sandboxes were silently missing the host mounts the operator's installed  per-distro runtime config specifies , including `/usr/sbin`, `/usr/lib`, and  `/etc/ssl` (the TLS trust store) — so HTTPS from jobs and `/usr/sbin` tooling were unavailable. Jobs only got the truncated built-in mount set.                                                                                                                                             
                                                                                                                                                                                                                
# Root cause                                                                                                                                                                                                 
                                                                                                                                                                                                                
The job init process configures itself from `config.InitConfig()` (built-in defaults overridden by values the server forwards over the process boundary).  
Only `Filesystem.*` was forwarded (`JOB_FS_*`), but the isolator also reads `Runtime.AllowedMounts` (`isolator.go:436`) and `Runtime.BasePath` (`isolator.go:1122`, `:1464`). With those unforwarded, init fell back to the four built-in `AllowedMounts` and ignored the distro `runtime-config.yml` the installer places on the host.                                                                                                                                                                                 
                                                                                                                                                                                                                
Regression from the config refactor that moved init off `LoadConfig()` (which read the runtime config file) onto `InitConfig()`; the runtime fields were left out of the forwarding contract.                                                                                                                                                                               
                                                                                                                                                                                                                
## Fix                                                                                                                                                                                                        
                                                                                                                                                                                                                
- `environment.ForwardRuntimeEnv` emits `JOB_RT_BASE_PATH` and `JOB_RT_ALLOWED_MOUNTS` (path-list joined), wired at every site that already forwards `JOB_FS_*`.                                                                                                                                                                                        
- `config.InitConfig` consumes both, overriding `Runtime.BasePath` /  `Runtime.AllowedMounts`.