### PR TITLE
fix: add validation

### DIFF
--- a/internal/joblet/core/filesystem/isolator.go
+++ b/internal/joblet/core/filesystem/isolator.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/ehsaniara/joblet/internal/joblet/core/validation"
 	"github.com/ehsaniara/joblet/internal/joblet/runtime"
 	"github.com/ehsaniara/joblet/pkg/config"
 	"github.com/ehsaniara/joblet/pkg/logger"
@@ -934,6 +935,17 @@ func (f *JobFilesystem) mountVolumes() error {
 func (f *JobFilesystem) mountSingleVolume(volumeName string) error {
 	log := f.logger.WithField("volume", volumeName)
 	// Mounting volume
+
+	// Defense in depth: the server already rejects malformed volume names at the
+	// API boundary, but this runs as root and builds bind-mount paths from the
+	// name, so re-verify the resolved mount point stays under the volumes base
+	// before creating any directory or mounting. A "../" name would otherwise
+	// escape the chroot's /volumes and land the mount anywhere on the host.
+	volumesBase := filepath.Join(f.RootDir, "volumes")
+	if _, err := validation.ValidatePathWithinBase(volumesBase, volumeName); err != nil {
+		log.Error("refusing to mount volume with unsafe name", "error", err, "volumeName", volumeName)
+		return fmt.Errorf("invalid volume name %q: %w", volumeName, err)
+	}
 
 	// Host volume path - this is where the actual volume data lives
 	hostVolumePath := fmt.Sprintf("%s/%s/data", f.getVolumesBasePath(), volumeName)

--- a/internal/joblet/server/job_service.go
+++ b/internal/joblet/server/job_service.go
@@ -279,9 +279,12 @@ func (s *JobServiceServer) validateJobRequest(req *interfaces.StartJobRequest) e
 		s.logger.Debug("using custom network", "network", req.Network)
 	}
 
+	// Volume names reach a root-side bind-mount path in the job init process;
+	// reject anything that isn't a plain name so a "../" name cannot escape the
+	// volume base or the job root.
 	for _, volume := range req.Volumes {
-		if volume == "" {
-			return fmt.Errorf("empty volume name not allowed")
+		if !domain.IsValidVolumeName(volume) {
+			return fmt.Errorf("invalid volume name %q: must be 1-63 characters of [a-zA-Z0-9_-], starting and ending alphanumeric", volume)
 		}
 	}
 

--- a/internal/joblet/server/job_service_validation_test.go
+++ b/internal/joblet/server/job_service_validation_test.go
@@ -144,3 +144,34 @@ func TestValidateJobRequest_NegativeGPUCount(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "gpuCount")
 }
+
+func TestValidateJobRequest_RejectsTraversalVolumeNames(t *testing.T) {
+	// Volume names reach a root-side bind-mount path in the job init process;
+	// a name containing "../" or a slash could escape the volumes base, so
+	// submission must reject anything that isn't a plain volume name.
+	s := newTestJobService(t.TempDir())
+
+	bad := []string{
+		"../etc",
+		"../../etc/passwd",
+		"foo/bar",
+		"/etc",
+		"..",
+		"foo/../bar",
+		"",
+	}
+	for _, name := range bad {
+		err := s.validateJobRequest(&interfaces.StartJobRequest{Volumes: []string{name}})
+		require.Error(t, err, "expected rejection for volume name %q", name)
+		assert.Contains(t, err.Error(), "volume name", "name %q", name)
+	}
+}
+
+func TestValidateJobRequest_AcceptsPlainVolumeNames(t *testing.T) {
+	s := newTestJobService(t.TempDir())
+
+	for _, name := range []string{"data", "my-vol", "vol_1", "cache123"} {
+		err := s.validateJobRequest(&interfaces.StartJobRequest{Volumes: []string{name}})
+		assert.NoError(t, err, "expected plain volume name %q to be accepted", name)
+	}
+}

--- a/tests/e2e/tests/01_isolation_test.sh
+++ b/tests/e2e/tests/01_isolation_test.sh
@@ -516,6 +516,36 @@ test_reserved_env_rejected() {
 
 run_test_check "Reserved environment variables rejected" test_reserved_env_rejected
 
+echo -e "\n${YELLOW}▶ 9b. Volume Name Traversal Rejection${NC}"
+echo -e "${BLUE}─────────────────────────────────────────────────────────────────${NC}"
+
+test_volume_traversal_rejected() {
+    # A volume name becomes a root-side bind-mount path in the job init process.
+    # A "../" name must be rejected at submission, otherwise it could escape the
+    # chroot's /volumes base and mount over an arbitrary host path.
+    local out=$("$RNX_BINARY" job run --volume="../../etc" echo should-not-run 2>&1)
+    local id=$(echo "$out" | grep "^ID:" | awk '{print $2}')
+
+    if [[ -z "$id" ]] && echo "$out" | grep -qiE "invalid volume name"; then
+        echo "    Traversal volume name '../../etc' rejected at submission"
+    else
+        echo "    Traversal volume name was NOT rejected (id=$id): $out"
+        return 1
+    fi
+
+    # A plain-name volume that simply does not exist must fail for a different
+    # reason (not-found), confirming the rejection above is about the name form.
+    local out2=$("$RNX_BINARY" job run --volume="no-such-volume-xyz" echo x 2>&1)
+    if echo "$out2" | grep -qiE "invalid volume name"; then
+        echo "    Plain volume name wrongly rejected as invalid: $out2"
+        return 1
+    fi
+    echo "    Plain volume name accepted by name validation (not rejected as invalid)"
+    return 0
+}
+
+run_test_check "Volume name traversal rejected" test_volume_traversal_rejected
+
 echo -e "\n${YELLOW}▶ 10. Runtime Allowed Mounts${NC}"
 echo -e "${BLUE}─────────────────────────────────────────────────────────────────${NC}"
 

--- a/tests/e2e/tests/05_volume_test.sh
+++ b/tests/e2e/tests/05_volume_test.sh
@@ -185,51 +185,40 @@ test_volume_creation() {
 }
 
 test_volume_mounting() {
-    # Test mounting a volume to a job with remote host verification
+    # A volume is referenced by bare name (rnx job run --volume=NAME) and always
+    # mounts inside the job at /volumes/<name> - the mount path is derived from
+    # the name, not client-supplied. Verify the volume created earlier actually
+    # mounts there and is writable.
     echo -e "    ${BLUE}Testing volume mounting on $TEST_HOST${NC}"
-    
+
+    local mount_path="/volumes/$TEST_VOLUME_NAME"
     local job_output=$("$RNX_BINARY" job run \
-        --volume="$TEST_VOLUME_NAME:/data" \
+        --volume="$TEST_VOLUME_NAME" \
         sh -c "
-if [ -d '/data' ]; then
+if [ -d '$mount_path' ]; then
     echo 'VOLUME_MOUNTED'
-    echo 'VOLUME_DATA' > /data/test.txt
+    echo 'VOLUME_DATA' > '$mount_path/test.txt'
     echo 'FILE_WRITTEN'
-    ls -la /data/
+    ls -la '$mount_path/'
 else
     echo 'NO_VOLUME'
 fi
 " 2>&1 || echo "")
-    
-    if echo "$job_output" | grep -q "volume.*not\|unrecognized option"; then
-        echo -e "    ${YELLOW}Volume mounting not supported${NC}"
-        return 0
+
+    local job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
+    if [[ -z "$job_id" ]]; then
+        echo -e "    ${RED}✗ Volume job was not accepted: $job_output${NC}"
+        return 1
     fi
-    
-    if echo "$job_output" | grep -q "ID:"; then
-        local job_id=$(echo "$job_output" | grep "^ID:" | awk '{print $2}')
-        local logs=$(get_job_logs "$job_id")
-        
-        # Client-side verification
-        if assert_contains "$logs" "VOLUME_MOUNTED" "Volume should be mounted"; then
-            echo -e "    ${GREEN}✓ Client-side volume mount verification passed${NC}"
-            
-            # Remote host verification - check if volume directory exists and file was written
-            echo -e "    ${BLUE}Verifying volume mount on remote host...${NC}"
-            if verify_remote_directory "/data" && verify_remote_file "/data/test.txt" "VOLUME_DATA"; then
-                echo -e "    ${GREEN}✓ Remote host volume verification passed${NC}"
-                return 0
-            else
-                echo -e "    ${YELLOW}Volume directory exists but file verification may be limited${NC}"
-                return 0
-            fi
-        else
-            echo -e "    ${YELLOW}Volume feature may be limited${NC}"
-            return 0
-        fi
-    else
-        return 0
+
+    local logs=$(get_job_logs "$job_id")
+    if ! assert_contains "$logs" "VOLUME_MOUNTED" "Volume should be mounted at $mount_path"; then
+        echo -e "    ${RED}✗ Volume did not mount at $mount_path${NC}"
+        return 1
     fi
+    assert_contains "$logs" "FILE_WRITTEN" "Volume should be writable" || return 1
+    echo -e "    ${GREEN}✓ Volume mounted at $mount_path and writable${NC}"
+    return 0
 }
 
 test_volume_persistence() {


### PR DESCRIPTION
- API boundary (internal/joblet/server/job_service.go), validateJobRequest now rejects any volume name failing domain.IsValidVolumeName (the same rule volume create already enforces), returning invalid volume name %q at submission.

- Root-side sink (internal/joblet/core/filesystem/isolator.go), mountSingleVolume re-verifies via validation.ValidatePathWithinBase that the resolved mount point stays under <RootDir>/volumes before creating any directory or mounting. This runs as root and builds the path from the name, so it re-checks the invariant even if a bad name ever reached it.

Related issue: #282