### PR TITLE
clean up docs

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -67,18 +67,12 @@ server:
   address: "0.0.0.0"               # Listen address
   port: 50051                      # gRPC port
   nodeId: ""                       # Unique node identifier (UUID, auto-generated during setup)
-
-  # TLS configuration
-  tls:
-    enabled: true                  # Enable TLS (recommended)
-    min_version: "1.3"            # Minimum TLS version
-
-  # Connection settings
-  max_message_size: 104857600     # Max gRPC message size (100MB)
-  keepalive:
-    time: 120s                    # Keepalive time
-    timeout: 20s                  # Keepalive timeout
 ```
+
+The `server:` section holds only these four fields. TLS is always required
+(mTLS) and is configured via embedded certificates under [`security:`](#security-settings);
+gRPC message sizes and keepalive settings live under the [`grpc:`](#grpc-configuration)
+section.
 
 ### Node Identification
 
@@ -125,107 +119,55 @@ joblet:
   # Default resource limits for jobs
   defaultCpuLimit: 100            # Default CPU limit (100 = 1 core)
   defaultMemoryLimit: 512         # Default memory limit in MB
-  defaultIoLimit: 10485760        # Default I/O limit in bytes/sec (10MB/s)
+  defaultIoLimit: 0               # Default I/O limit in bytes/sec (0 = unlimited)
 
   # Job execution settings
   maxConcurrentJobs: 100          # Maximum concurrent jobs
-  jobTimeout: "24h"               # Maximum job runtime (0 = unlimited). Can be overridden per-job with --timeout flag
-
-  # Command validation
-  validateCommands: true          # Validate commands before execution
+  jobTimeout: "1h"                # Maximum job runtime (0 = unlimited). Can be overridden per-job with --timeout flag
 
   # Cleanup settings
-  cleanupTimeout: "30s"          # Timeout for cleanup operations
-
-  # Isolation configuration
-  isolation:
-    service_based_routing: true   # Enable automatic service-based job routing
-
-    # Production jobs (JobService API)
-    production:
-      type: "minimal_chroot"      # Minimal chroot isolation
-      runtime_isolation: true     # Use isolated runtime copies
-      # NOTE: allowed_mounts is now configured under runtime.allowed_mounts
-
-    # Runtime build jobs (RuntimeService API)
-    builder:
-      type: "builder_chroot"      # Builder chroot with controlled host access
-      host_access: "readonly"     # Host filesystem access level
-      runtime_cleanup: true       # Automatic runtime cleanup after build
-      cleanup_on_completion: true # Clean up builder environment
+  cleanupTimeout: "5s"            # Timeout for cleanup operations
 ```
+
+These six fields are the entire `joblet:` section. Job isolation (chroot,
+namespaces, OverlayFS runtime isolation) is applied automatically and is not
+configurable here.
 
 ### Network Configuration
 
 ```yaml
 network:
-  enabled: true                   # Enable network management
+  enabled: true                    # Enable network management
   state_dir: "/opt/joblet/network" # Network state directory
 
   # Default network settings
-  default_network: "bridge"       # Default network for jobs
-  allow_custom_networks: true     # Allow custom network creation
-  max_custom_networks: 50         # Maximum custom networks
+  default_network: "bridge"        # Default network for jobs
+  allow_custom_networks: true      # Allow custom network creation
 
-  # Predefined networks
+  # Persistent network state storage
+  storage:
+    path: "/opt/joblet/network"    # Where network state is persisted
+
+  # Predefined networks. Each network has only these two fields.
   networks:
     bridge:
-      cidr: "172.20.0.0/16"      # Bridge network CIDR
-      bridge_name: "joblet0"      # Bridge interface name
-      enable_nat: true            # Enable NAT for internet access
-      enable_icc: true            # Inter-container communication
-
-    host:
-      type: "host"                # Use host network namespace
-
-    none:
-      type: "none"                # No network access
-
-  # DNS configuration
-  dns:
-    servers:
-      - "8.8.8.8"
-      - "8.8.4.4"
-    search:
-      - "local"
-    options:
-      - "ndots:1"
-
-  # Traffic control
-  traffic_control:
-    enabled: true                 # Enable bandwidth limiting
-    default_ingress: 0            # Default ingress limit (0 = unlimited)
-    default_egress: 0             # Default egress limit
+      cidr: "172.20.0.0/16"        # Bridge network CIDR
+      bridge_name: "joblet0"       # Bridge interface name
 ```
+
+The built-in `host` and `none` networks (host namespace / no network) are
+handled internally and are not declared in this section. Each entry under
+`networks:` accepts only `cidr` and `bridge_name`.
 
 ### Volume Configuration
 
 ```yaml
-volume:
-  enabled: true                   # Enable volume management
-  state_dir: "/opt/joblet/state"  # Volume state directory
-  base_path: "/opt/joblet/volumes" # Volume storage path
-
-  # Volume limits
-  max_volumes: 100                # Maximum number of volumes
-  max_size: "100GB"              # Maximum total volume size
-  default_size: "1GB"            # Default volume size
-
-  # Volume types configuration
-  filesystem:
-    enabled: true
-    default_fs: "ext4"           # Default filesystem type
-    mount_options: "noatime,nodiratime"
-
-  memory:
-    enabled: true
-    max_memory_volumes: 10       # Maximum memory volumes
-    max_memory_usage: "10GB"     # Maximum total memory usage
-
-  # Cleanup settings
-  auto_cleanup: false            # Auto-remove unused volumes
-  cleanup_interval: "24h"        # Cleanup check interval
+volumes:
+  base_path: "/opt/joblet/volumes"      # Volume storage path
+  default_disk_quota_bytes: 1048576     # Default per-volume disk quota in bytes (1MB)
 ```
+
+The `volumes:` section (note the plural key) has only these two fields.
 
 ### Runtime Configuration
 
@@ -288,25 +230,15 @@ security:
     -----BEGIN CERTIFICATE-----
     MIIFazCCA1OgAwIBAgIUX...
     -----END CERTIFICATE-----
-
-  # Authentication settings
-  require_client_cert: true       # Require client certificates
-  verify_client_cert: true        # Verify client certificates
-
-  # Authorization
-  enable_rbac: true              # Enable role-based access control
-  # Role comes from the client certificate OU: admin, maintainer,
-  # developer, or reader (the old "viewer" still works and maps to
-  # reader). Anything else is rejected.
-
-  # Audit logging
-  audit:
-    enabled: true
-    log_file: "/var/log/joblet/audit.log"
-    log_successful_auth: true
-    log_failed_auth: true
-    log_job_operations: true
 ```
+
+The `security:` section holds only these three embedded PEM fields:
+`serverCert`, `serverKey`, and `caCert`. There are no toggles for client-cert
+verification or RBAC — mTLS is always enforced (the server requires and
+verifies client certificates against `caCert`), and role-based access control
+is always on. A client's role is derived from the OU field of its certificate:
+`admin`, `maintainer`, `developer`, or `reader` (the old `viewer` still works
+and maps to `reader`). Any other OU is rejected.
 
 ### Buffer Configuration
 
@@ -589,97 +521,63 @@ characteristics, DynamoDB setup, monitoring, and troubleshooting.
 
 ```yaml
 logging:
-  level: "info"                  # Log level: debug, info, warn, error
-  format: "json"                 # Log format: json or text
-
-  # Output configuration
-  outputs:
-    - type: "file"
-      path: "/var/log/joblet/joblet.log"
-      rotate: true
-      max_size: "100MB"
-      max_backups: 10
-      max_age: 30
-
-    - type: "stdout"
-      format: "text"             # Override format for stdout
-
-  # Component-specific logging
-  components:
-    grpc: "warn"
-    cgroup: "info"
-    network: "info"
-    volume: "info"
-    auth: "info"
+  level: "INFO"                  # Log level: DEBUG, INFO, WARN, ERROR (case-insensitive)
+  format: "text"                 # Log format: text or json
+  output: "stdout"               # Single output destination (e.g. "stdout")
 ```
+
+The `logging:` section has exactly three fields: `level`, `format`, and a
+single `output` string. There is no multi-output list or per-component log
+configuration.
 
 ### Advanced Settings
 
 ```yaml
-# Cgroup configuration
+# Cgroup configuration (cgroups v2 only)
 cgroup:
-  baseDir: "/sys/fs/cgroup/joblet.slice" # Cgroup hierarchy path
-  version: "v2"                          # Cgroup version (v1 or v2)
+  baseDir: "/sys/fs/cgroup/joblet.slice/joblet.service" # Cgroup hierarchy path
+  namespaceMount: "/sys/fs/cgroup"                       # Cgroup namespace mount point
 
   # Controllers to enable
   enableControllers:
-    - memory
     - cpu
+    - memory
     - io
     - pids
     - cpuset
+    - devices
 
-  # Resource accounting
-  accounting:
-    enabled: true
-    interval: "10s"              # Metrics collection interval
+  cleanupTimeout: "5s"           # Timeout for cgroup cleanup operations
 
 # Filesystem isolation
 filesystem:
   baseDir: "/opt/joblet/jobs"    # Base directory for job workspaces
-  tmpDir: "/opt/joblet/tmp"      # Temporary directory
+  tmpDir: "/tmp/job-{JOB_ID}"    # Per-job temporary directory template
+  workspaceDir: "/work"          # Workspace mount point inside the job
 
-  # Workspace settings
-  workspace:
-    default_quota: "1MB"         # Default workspace size
-    cleanup_on_exit: true        # Clean workspace after job
-    preserve_on_failure: true    # Keep workspace on failure
-
-  # Security
-  enable_chroot: true            # Use chroot isolation
-  readonly_rootfs: false         # Make root filesystem read-only
-
-# Process management
-process:
-  default_user: "nobody"         # Default user for jobs
-  default_group: "nogroup"       # Default group for jobs
-  allow_setuid: false           # Allow setuid in jobs
-
-  # Namespace configuration
-  namespaces:
-    - pid                       # Process isolation
-    - mount                     # Filesystem isolation
-    - network                   # Network isolation
-    - ipc                       # IPC isolation
-    - uts                       # Hostname isolation
-    - cgroup                    # Cgroup isolation
-
-# Monitoring configuration
+# Monitoring configuration (system-level host metrics)
 monitoring:
-  enabled: true
-  bind_address: "127.0.0.1:9090" # Prometheus metrics endpoint
+  system_interval: "10s"         # How often to sample host system metrics
+  cloud_detection: true          # Detect cloud provider/instance metadata
+```
 
-  collection:
-    system_interval: "15s"       # System metrics interval
-    process_interval: "30s"      # Process metrics interval
+The `cgroup:`, `filesystem:`, and `monitoring:` sections have only the fields
+shown above. Chroot isolation and job namespaces are applied automatically and
+are not configurable. There is no separate `process:` section.
 
-  # Metrics to collect
-  metrics:
-    - cpu
-    - memory
-    - disk
-    - network
-    - processes
+### gRPC Configuration
+
+gRPC message sizes and keepalive/timeout settings live in the `grpc:` section:
+
+```yaml
+grpc:
+  maxRecvMsgSize: 134217728        # Max received message size (default: 128MB)
+  maxSendMsgSize: 134217728        # Max sent message size (default: 128MB)
+  maxHeaderListSize: 16777216      # Max header list size (default: 16MB)
+  keepAliveTime: "10s"             # Keepalive ping interval
+  keepAliveTimeout: "3s"           # Keepalive ping timeout
+  maxConcurrentStreams: 1000       # Max concurrent streams per connection
+  connectionTimeout: "10s"         # Connection establishment timeout
 ```
 
 ## Client Configuration
@@ -899,13 +797,12 @@ openssl req -new -key client-key.pem -out reader.csr \
 
 | Variable                     | Description                        | Default                                 |
 |------------------------------|------------------------------------|-----------------------------------------|
-| `JOBLET_CONFIG_PATH`         | Path to main configuration file    | `/opt/joblet/config/joblet-config.yml`  |
-| `JOBLET_RUNTIME_CONFIG_PATH` | Path to runtime configuration file | `/opt/joblet/config/runtime-config.yml` |
-| `JOBLET_LOG_LEVEL`           | Log level override                 | from config                             |
+| `JOBLET_CONFIG_PATH`         | Path to main configuration file    | searches standard locations             |
+| `JOBLET_RUNTIME_CONFIG_PATH` | Path to runtime configuration file | searches standard locations             |
 | `JOBLET_SERVER_ADDRESS`      | Server address override            | from config                             |
-| `JOBLET_SERVER_PORT`         | Server port override               | from config                             |
-| `JOBLET_NODE_ID`             | Node identifier override           | from config                             |
-| `JOBLET_MAX_JOBS`            | Maximum concurrent jobs            | from config                             |
+| `JOBLET_MODE`                | Server mode override (`server`/`init`) | from config                         |
+| `JOBLET_LOG_LEVEL`           | Log level override                 | from config                             |
+| `JOBLET_LOG_FORMAT`          | Log format override (`text`/`json`) | from config                            |
 
 ### Client Environment Variables
 
@@ -919,42 +816,33 @@ openssl req -new -key client-key.pem -out reader.csr \
 
 ### High-Security Production Setup
 
+TLS (mTLS) is always enforced via the embedded certificates under `security:`,
+so there are no TLS or RBAC toggles to set here.
+
 ```yaml
 version: "3.0"
 
 server:
   address: "0.0.0.0"
   port: 50051
-  tls:
-    enabled: true
-    min_version: "1.3"
-    cipher_suites:
-      - TLS_AES_256_GCM_SHA384
-      - TLS_CHACHA20_POLY1305_SHA256
 
 joblet:
-  validateCommands: true
-  allowedCommands:
-    - python3
-    - node
   maxConcurrentJobs: 50
   jobTimeout: "1h"
 
 security:
-  require_client_cert: true
-  verify_client_cert: true
-  enable_rbac: true
-  audit:
-    enabled: true
-    log_all_operations: true
-
-filesystem:
-  enable_chroot: true
-  readonly_rootfs: true
-
-process:
-  default_user: "nobody"
-  allow_setuid: false
+  serverCert: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+  serverKey: |
+    -----BEGIN PRIVATE KEY-----
+    ...
+    -----END PRIVATE KEY-----
+  caCert: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
 ```
 
 ### Development Environment Setup
@@ -970,21 +858,20 @@ joblet:
   defaultCpuLimit: 0      # No limits in dev
   defaultMemoryLimit: 0
   defaultIoLimit: 0
-  validateCommands: false # Allow any command
 
 logging:
-  level: "debug"
+  level: "DEBUG"
   format: "text"
 
 network:
   networks:
     bridge:
       cidr: "172.30.0.0/16"
-      enable_nat: true
+      bridge_name: "joblet0"
 
-volume:
-  max_volumes: 1000
-  max_size: "1TB"
+volumes:
+  base_path: "/opt/joblet/volumes"
+  default_disk_quota_bytes: 1048576
 ```
 
 ### CI/CD Optimized Setup
@@ -1000,22 +887,11 @@ joblet:
   maxConcurrentJobs: 200
   jobTimeout: "30m"
   cleanupTimeout: "5s"
-  preserveFailedJobs: false
-
-filesystem:
-  workspace:
-    cleanup_on_exit: true
-    preserve_on_failure: false
-
-cgroup:
-  accounting:
-    enabled: false      # Reduce overhead
 
 logging:
-  level: "warn"        # Reduce log volume
-  outputs:
-    - type: "stdout"
-      format: "json"   # Structured logs for CI
+  level: "WARN"        # Reduce log volume
+  format: "json"       # Structured logs for CI
+  output: "stdout"
 ```
 
 ## Best Practices
@@ -1024,10 +900,9 @@ logging:
 2. **Resource Limits**: Set appropriate defaults to prevent resource exhaustion
 3. **Monitoring**: Enable metrics collection for production environments
 4. **Logging**: Use JSON format for easier log parsing
-5. **Cleanup**: Configure automatic cleanup to prevent disk space issues
-6. **Validation**: Enable command validation in production
-7. **Audit**: Enable audit logging for compliance
-8. **Backup**: Keep configuration file backups
+5. **State Persistence**: Use the `local` or `dynamodb` state backend so jobs survive restarts
+6. **Access Control**: Issue per-role client certificates (OU = admin/maintainer/developer/reader); RBAC is enforced automatically via mTLS
+7. **Backup**: Keep configuration file backups
 
 ## Configuration Validation
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -162,16 +162,15 @@ Joblet validates environment variables for:
 
 ### Name Validation
 
-- Format: `^[A-Z][A-Z0-9_]*$`
-- Must start with uppercase letter
-- Can contain uppercase letters, numbers, and underscores
-- Maximum length: 256 characters
+- Format: `^[a-zA-Z_][a-zA-Z0-9_]*$`
+- Must start with a letter or underscore
+- Can contain letters (upper or lower case), numbers, and underscores
+- No maximum name length is enforced
 
 ### Value Validation
 
-- Maximum size: 32KB per variable
-- No null bytes allowed
-- UTF-8 encoding required
+- Maximum size: 32KB (32768 bytes) per variable value
+- No other content checks are applied (no null-byte or UTF-8 validation)
 
 ### Conflict Detection
 
@@ -185,7 +184,24 @@ jobs:
 
 ### Reserved Variables
 
-Warning issued for system variables:
+#### Rejected (hard error)
+
+The server **rejects the job outright** (gRPC error, job not created) if any
+client-supplied variable — from **either** `--env` or `--secret-env` — collides
+with the reserved joblet namespace. These names are controlled by the runtime
+and cannot be set by a client:
+
+- Any name starting with the prefix `JOB_`
+- Any name starting with the prefix `JOBLET_`
+- The exact name `RUNTIME_MANAGER_PATH`
+- The exact name `NETWORK_READY_FILE`
+
+Setting any of these causes the run to fail immediately rather than being
+silently stripped.
+
+#### Warned (system variables)
+
+A soft warning (the job still runs) is issued for common system variables:
 
 - `PATH`, `HOME`, `USER`, `SHELL`
 - `PWD`, `OLDPWD`, `LANG`

--- a/docs/GPU_SUPPORT.md
+++ b/docs/GPU_SUPPORT.md
@@ -6,13 +6,21 @@ allocation, memory isolation, and CUDA environment integration.
 
 ## Executive Overview
 
-Joblet's GPU orchestration framework enables organizations to:
+> ⚠️ **Status:** GPU support is currently partial/experimental. GPU discovery, allocation
+> bookkeeping, request validation, and `CUDA_VISIBLE_DEVICES` / `NVIDIA_VISIBLE_DEVICES` env
+> injection work today. Runtime memory enforcement, hardware-level device isolation, and automatic
+> CUDA library provisioning are designed but **not yet wired into the execution path** — see the
+> notes in the sections below.
 
-- **Automated GPU Discovery and Allocation**: Intelligent assignment of GPU resources based on job requirements
-- **Memory Quota Management**: Enforce GPU memory constraints to prevent resource contention
-- **Hardware-Level Isolation**: Secure GPU access boundaries between concurrent workloads
-- **Comprehensive Observability**: Real-time GPU utilization metrics through multiple interfaces
-- **CUDA Integration**: Automatic CUDA runtime provisioning and library path configuration
+Joblet's GPU orchestration framework is designed to enable organizations to:
+
+- **Automated GPU Discovery and Allocation**: Assignment of GPU resources based on job requirements *(working)*
+- **Memory Quota Management** *(not yet enforced)*: `--gpu-memory` filters candidate GPUs at selection time only; it is
+  not enforced at runtime
+- **Hardware-Level Isolation** *(planned)*: Per-job device access boundaries are designed but not yet applied
+- **Comprehensive Observability**: GPU allocation metadata through multiple interfaces
+- **CUDA Integration**: `CUDA_VISIBLE_DEVICES` env configuration *(working)*; automatic CUDA library provisioning is
+  *planned, not yet active*
 
 ## Getting Started with GPU Workloads
 
@@ -63,17 +71,30 @@ rnx job run --gpu=1 --max-cpu=400 --max-memory=16384 python hybrid_workload.py
 
 ### CUDA Runtime Integration
 
-Upon GPU allocation request, Joblet performs the following automated operations:
+> ⚠️ **Current state:** Today Joblet provides GPU visibility to jobs through environment variables
+> only. Per-job device-node passthrough (`/dev/nvidia*`), cgroup device access controls, and CUDA
+> library bind-mounting are designed but **not yet wired into the execution path**. Steps 3 and 4
+> below are not active yet, so `nvidia-smi` and CUDA libraries are only usable inside a job if they
+> already exist in the job's runtime/host filesystem — Joblet does not currently provision or
+> restrict them per job.
+
+Upon GPU allocation request, Joblet performs the following operations:
 
 1. **GPU Discovery**: Enumerates available NVIDIA devices via `/proc/driver/nvidia/gpus/` and `nvidia-smi` interfaces
-2. **Device Allocation**: Assigns specific GPU indices to job instances with tracking in job metadata
-3. **Permission Configuration**: Establishes appropriate device access controls for job namespaces
-4. **Library Provisioning**: Binds CUDA runtime libraries from system installation paths
-5. **Environment Setup**: Configures `CUDA_VISIBLE_DEVICES` for framework compatibility
+2. **Device Allocation**: Assigns specific GPU indices to job instances with tracking in job metadata (in-memory bookkeeping)
+3. **Permission Configuration** *(not yet active)*: Intended to establish per-job device access controls; the cgroup
+   device path currently logs and returns without applying any rules
+4. **Library Provisioning** *(not yet active)*: Intended to bind CUDA runtime libraries into the job; the execution
+   path currently only logs a placeholder and mounts nothing
+5. **Environment Setup**: Configures `CUDA_VISIBLE_DEVICES` and `NVIDIA_VISIBLE_DEVICES` for framework compatibility
 
 ### CUDA Library Path Resolution
 
-Joblet automatically discovers and mounts CUDA installations from standard locations:
+> ⚠️ **Not yet active:** CUDA library bind-mounting into the job namespace is not currently wired
+> into the execution path. The paths below describe where Joblet is designed to discover CUDA
+> installations; today no CUDA libraries are mounted into jobs by Joblet.
+
+Joblet is designed to discover CUDA installations from standard locations:
 
 - `/usr/local/cuda`
 - `/opt/cuda`

--- a/docs/GPU_SUPPORT_DESIGN.md
+++ b/docs/GPU_SUPPORT_DESIGN.md
@@ -95,6 +95,11 @@ GPUDevice:
 
 ### 2.3 Resource Isolation Integration
 
+> ⚠️ **DESIGN / PLANNED — not delivered.** The cgroups v2 device controller and GPU memory limits
+> described in this section are the intended design. They are **not** wired into the current
+> execution path: the cgroup GPU device code logs and returns without writing device rules, and
+> `--gpu-memory` is only used to filter candidate GPUs at selection time, not enforced at runtime.
+
 #### Cgroups v2 Device Controller
 
 ```yaml
@@ -124,6 +129,12 @@ Cgroup Path Structure:
 - **Method 3**: MIG (Multi-Instance GPU) partitioning for hard limits
 
 ### 2.4 Filesystem Isolation Extensions
+
+> ⚠️ **DESIGN / PLANNED — not delivered.** The chroot GPU device-node creation (`mknod`) and CUDA
+> library bind-mounts described here are the intended design. Working implementations exist in the
+> filesystem isolator (`internal/joblet/core/filesystem/isolator.go`) but are currently **dead
+> code** — the execution path calls placeholder adapters that only log and return, so jobs do not
+> receive `/dev/nvidia*` nodes or bind-mounted CUDA libraries today.
 
 #### GPU Device Nodes in Chroot
 
@@ -457,12 +468,15 @@ Log Events:
 
 ### Functional Requirements
 
-- ✓ Detect and enumerate NVIDIA GPUs
-- ✓ Allocate GPUs to jobs based on requirements
-- ✓ Pass through GPU devices to isolated jobs
-- ✓ Mount CUDA libraries in job environment
-- ✓ Enforce GPU resource limits
-- ✓ Clean up GPU resources after job completion
+> ⚠️ These are target criteria. Checkmarks below indicate design intent, not current delivery
+> status. Items marked *(planned)* are not yet wired into the execution path.
+
+- ✓ Detect and enumerate NVIDIA GPUs *(working)*
+- ✓ Allocate GPUs to jobs based on requirements *(working — in-memory bookkeeping)*
+- ✓ Pass through GPU devices to isolated jobs *(planned — device nodes not yet created in jobs)*
+- ✓ Mount CUDA libraries in job environment *(planned — bind-mount not yet wired)*
+- ✓ Enforce GPU resource limits *(planned — `--gpu-memory` filters at selection only, not enforced)*
+- ✓ Clean up GPU resources after job completion *(partial — allocation bookkeeping released; GPU memory not reliably cleared)*
 
 ### Performance Requirements
 

--- a/docs/GPU_TESTING.md
+++ b/docs/GPU_TESTING.md
@@ -46,6 +46,13 @@ go test ./tests/gpu -v
 
 ### 3. System Tests (Real GPUs)
 
+> ⚠️ **Caveat — device-node passthrough is not yet wired.** Joblet does not currently create
+> `/dev/nvidia*` device nodes inside a job or bind-mount CUDA libraries. As a result, running
+> `nvidia-smi` or checking for `/dev/nvidia*` **inside a job** will not find GPU devices, even on a
+> host with working GPUs. What a job does receive today is the `CUDA_VISIBLE_DEVICES` /
+> `NVIDIA_VISIBLE_DEVICES` environment variables. The `nvidia-smi` checks below only work when run
+> **on the host**, not inside a job.
+
 #### Prerequisites
 
 - NVIDIA GPU installed
@@ -63,17 +70,19 @@ export GPU_TEST_MODE=real
 ./tests/e2e/tests/09_gpu_test.sh
 
 # Test specific GPU scenarios
+# NOTE: `nvidia-smi` inside a job will NOT see GPUs today (no device-node passthrough).
+# It only works if nvidia-smi and the driver devices are already present in the job's filesystem.
 rnx job run --gpu=1 --gpu-memory=4GB nvidia-smi
 rnx job run --gpu=2 --gpu-memory=8GB python gpu_test.py
 ```
 
 #### What System Tests Cover
 
-- Actual GPU allocation and isolation
-- CUDA environment setup
-- Device node creation (`/dev/nvidia*`)
-- Real GPU memory limits
-- Multi-GPU scenarios
+- GPU allocation bookkeeping
+- `CUDA_VISIBLE_DEVICES` / `NVIDIA_VISIBLE_DEVICES` environment setup
+- Device node creation (`/dev/nvidia*`) — *not yet wired; these nodes will not appear inside a job*
+- GPU memory selection filtering (runtime limits *not yet enforced*)
+- Multi-GPU allocation scenarios
 
 ## Test Scenarios by Environment
 
@@ -221,12 +230,17 @@ rnx job status <job-uuid>  # Should show GPU info if allocated
 
 ### Check Job GPU Environment
 
+> ⚠️ Only the `CUDA_VISIBLE_DEVICES` / `env | grep CUDA` checks below will succeed today. Because
+> device-node passthrough is not yet wired, `ls -la /dev/nvidia*` will report "No such file or
+> directory" and `nvidia-smi` will fail inside the job even when the host has working GPUs. This is
+> expected in the current implementation, not a misconfiguration.
+
 ```bash
 # Create debug job
 rnx job run --gpu=1 bash -c "
   echo 'CUDA_VISIBLE_DEVICES='$CUDA_VISIBLE_DEVICES
-  ls -la /dev/nvidia*
-  nvidia-smi || echo 'nvidia-smi not available'
+  ls -la /dev/nvidia*                 # not yet wired: expect no nodes inside the job
+  nvidia-smi || echo 'nvidia-smi not available'   # not yet wired: expect failure inside the job
   env | grep CUDA
 "
 ```

--- a/docs/ISOLATION_SECURITY_ANALYSIS.md
+++ b/docs/ISOLATION_SECURITY_ANALYSIS.md
@@ -57,36 +57,36 @@ Production Chroot: /opt/joblet/jobs/{JOB_ID}/
 
 ### 2. Runtime Build Jobs (RuntimeService → `runtime-build` jobs)
 
-**Isolation Method:** Builder chroot with controlled host filesystem access
+**Isolation Method:** OverlayFS build environment layered over the host root
 
-**Implementation:** `jobFS.SetupBuilder()` in `filesystem/isolator.go`
+**Implementation:** `IsolatedEnvironment.Setup()` in `pkg/builder/isolation.go`
 
 **Security Boundaries:**
 
+The live `rnx runtime build` path mounts an OverlayFS in which the host root (`/`) is the **read-only lower layer**, an
+upper layer captures every write, and the merged view is what the build process actually sees:
+
 ```text
-Builder Chroot: /opt/joblet/jobs/{BUILD_ID}/
-├── bin/          # Full /bin from host (read-only bind mount)
-├── lib/          # Full /lib from host (read-only bind mount)
-├── usr/          # Full /usr from host (read-only bind mount)  
-├── etc/          # Full /etc from host (read-only bind mount)
-├── var/          # Full /var from host (read-only bind mount)
-├── home/         # Full /home from host (read-only bind mount)
-├── root/         # Full /root from host (read-only bind mount)
-├── work/         # Build workspace (writable, isolated)
-├── tmp/          # Isolated tmp: /tmp/job-{BUILD_ID}/ (writable, isolated)
-└── opt/
-    ├── [other]/  # Other /opt contents (read-only bind mount)
-    └── joblet/
-        └── runtimes/  # ONLY runtimes dir (read-write bind mount)
+OverlayFS build environment:
+  lowerdir = /                # Host root, READ-ONLY (writes never reach it)
+  upperdir = <build>/upper    # All writes land here, isolated from the host
+  workdir  = <build>/work     # OverlayFS bookkeeping (required by overlayfs)
+  merged   = <build>/merged   # Unified view the build process operates on
 ```
+
+Because the host root is the lower layer, the build has full read access to the host OS environment for compilation but
+cannot modify any host file - writes are redirected into the upper layer and discarded (or promoted into the runtime
+tree) at the end of the build. Package managers (`apt`, `pip`, `npm`) work because runtime builds share host
+networking and have working DNS.
 
 **Key Security Features:**
 
-- **Host filesystem (read-only)**: Full OS environment for compilation
-- **Recursive exclusion prevention**: `/opt/joblet/` completely excluded except `runtimes/`
-- **Controlled write access**: Only `/opt/joblet/runtimes/` is writable
-- **Isolated tmp**: Each build gets `/tmp/job-{BUILD_ID}/`
-- **Same process isolation**: PID namespace, cgroups, etc.
+- **Host root as read-only lower layer**: The build sees the full OS but every write is redirected into the upper
+  layer; the host filesystem is never modified.
+- **Writes isolated in the upper layer**: Build output is captured separately; only the produced runtime tree is
+  promoted.
+- **Isolated tmp**: Each build gets its own temporary space.
+- **Same process isolation**: PID, mount, IPC, UTS, and cgroup namespaces (runtime builds share host networking).
 
 ## Critical Security Analysis
 
@@ -176,15 +176,20 @@ func (i *Isolator) CreateBuilderFilesystem(jobID string) (*JobFilesystem, error)
 
 ### 4. Process Isolation Parity - SECURE
 
-Both job types use identical process isolation:
+Both job types use the same core process isolation:
 
 **Shared Security Features:**
 
 - **PID Namespace**: Each job is PID 1 in its own namespace
 - **Mount Namespace**: Isolated mount table
-- **Network Namespace**: Controlled networking (bridge mode)
 - **Cgroups**: Resource limits (CPU, memory, I/O)
-- **User Namespace**: Same unprivileged user context
+- **Privilege drop, not UID remapping**: No user namespace (`CLONE_NEWUSER`) is used - it is deliberately omitted
+  because it breaks the mount operations Joblet relies on. Instead, isolation of the user context comes from dropping
+  privileges to uid/gid 65534 (nobody) after isolation setup but before the job command executes.
+
+**Where they differ:** the **Network Namespace** is not shared behavior - production jobs get their own network
+namespace (bridge networking), while runtime-build jobs share the host network stack for internet access during the
+build.
 
 **Implementation Verification:**
 

--- a/docs/JOB_EXECUTION.md
+++ b/docs/JOB_EXECUTION.md
@@ -250,7 +250,8 @@ rnx job run --schedule="2h" cleanup.sh
 # Run in 30 seconds
 rnx job run --schedule="30s" quick_task.sh
 
-# Supported units: s, m, min, h, d
+# Supported units: s/sec/secs/second/seconds, m/min/mins/minute/minutes, h/hour/hours
+# Minimum 1 second, maximum 1 year (no day unit)
 ```
 
 ### Absolute Time Scheduling
@@ -273,11 +274,11 @@ rnx job run --schedule="$TOMORROW_NOON" lunch_reminder.sh
 # List scheduled jobs
 rnx job list --json | jq '.[] | select(.status == "SCHEDULED")'
 
-# Cancel scheduled job
-rnx job stop <job-uuid>
+# Cancel scheduled job (use cancel, not stop, for SCHEDULED jobs)
+rnx job cancel <job-uuid>
 
 # Example with actual UUID:
-rnx job stop f47ac10b-58cc-4372-a567-0e02b2c3d479
+rnx job cancel f47ac10b-58cc-4372-a567-0e02b2c3d479
 
 # Check when job will run
 rnx job status <job-uuid>
@@ -358,7 +359,7 @@ rnx job status <job-uuid> | grep "Exit Code"
 rnx job log <job-uuid> | tail -20
 
 # Script to wait for completion
-JOB_UUID=$(rnx job run --json long_task.sh | jq -r .id)
+JOB_UUID=$(rnx job run --json long_task.sh | jq -r .job_uuid)
 # JOB_UUID will be something like: f47ac10b-58cc-4372-a567-0e02b2c3d479
 while [[ $(rnx job status --json $JOB_UUID | jq -r .status) == "RUNNING" ]]; do
   sleep 5
@@ -480,7 +481,7 @@ rnx job telematics f47ac10b --types exec,connect,accept
 PREP_JOB=$(rnx job run --json \
   --volume=pipeline-data \
   --upload=prepare_data.py \
-  python3 prepare_data.py | jq -r .id)
+  python3 prepare_data.py | jq -r .job_uuid)
 # PREP_JOB will be something like: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 # Wait for completion
@@ -509,7 +510,7 @@ rnx job run \
 
 ```bash
 # Simple dependency chain
-JOB1=$(rnx job run --json setup.sh | jq -r .id)
+JOB1=$(rnx job run --json setup.sh | jq -r .job_uuid)
 # JOB1 will be something like: 12345678-abcd-ef12-3456-7890abcdef12
 # Wait for job1
 while [[ $(rnx job status --json $JOB1 | jq -r .status) == "RUNNING" ]]; do
@@ -589,7 +590,7 @@ submit_job() {
   local retry=0
   
   while [ $retry -lt $max_retries ]; do
-    JOB_UUID=$(rnx job run --json $cmd | jq -r .id)
+    JOB_UUID=$(rnx job run --json $cmd | jq -r .job_uuid)
     
     if [ $? -eq 0 ]; then
       echo "Job submitted: $JOB_UUID"  # e.g., f47ac10b-58cc-4372-a567-0e02b2c3d479
@@ -620,7 +621,7 @@ rnx job run --volume=temp-vol process_data.sh
 ```bash
 # Comprehensive logging
 JOB_UUID=$(rnx job run --json \
-  backup.sh | jq -r .id)
+  backup.sh | jq -r .job_uuid)
 # JOB_UUID will be something like: f47ac10b-58cc-4372-a567-0e02b2c3d479
 
 # Save all job info

--- a/docs/METRICS_CONFIGURATION.md
+++ b/docs/METRICS_CONFIGURATION.md
@@ -14,25 +14,36 @@ tracking with minimal performance overhead. You can customize the configuration 
 
 ### Basic Configuration
 
-Add the following section to your `/opt/joblet/joblet-config.yml` (or your custom config path):
+Metrics collection is configured under the `telemetry:` section of your
+`/opt/joblet/config/joblet-config.yml` (or your custom config path):
 
 ```yaml
-job_metrics:
-  enabled: true                       # Enable metrics collection
-  default_sample_rate: 5s             # Sample every 5 seconds
-  storage_dir: "/opt/joblet/metrics"  # Where to store metrics files
-  retention_days: 7                   # Keep metrics for 7 days
+telemetry:
+  # How often to sample resource metrics (CPU, memory, disk I/O, network)
+  metrics_interval: "5s"     # Default: 5 seconds (minimum: 1s)
+
+  # eBPF-based activity tracking (Linux 5.8+ required)
+  ebpf_enabled: true         # Enable eBPF telemetry collection (default: true)
+
+  # Enabled eBPF event types (omit or leave empty for all)
+  # Valid values: exec, connect, accept, mmap, mprotect, file, socket_data
+  event_types:
+    - exec
+    - connect
+    - accept
 ```
 
-### Full Configuration Example
+### Fields
 
-```yaml
-job_metrics:
-  enabled: true                       # Enable metrics collection
-  default_sample_rate: 5s             # Sample every 5 seconds
-  storage_dir: "/opt/joblet/metrics"  # Where to store metrics files
-  retention_days: 7                   # Keep metrics for 7 days
-```
+| Field              | Type     | Default | Description                                                                 |
+|--------------------|----------|---------|-----------------------------------------------------------------------------|
+| `metrics_interval` | duration | `5s`    | How often to sample resource metrics (minimum: 1s)                          |
+| `ebpf_enabled`     | bool     | `true`  | Enable eBPF telemetry collection (requires Linux 5.8+)                       |
+| `event_types`      | list     | all     | Enabled eBPF event types; empty/omitted means all types are enabled         |
+
+Storage location and retention for metrics are handled by the persist service
+(`persist.storage`), not by the telemetry section. See
+[CONFIGURATION.md](CONFIGURATION.md) and [PERSISTENCE.md](PERSISTENCE.md) for details.
 
 ## Prerequisites
 
@@ -206,7 +217,7 @@ Metrics collection has minimal overhead:
 
 ### Metrics Not Showing
 
-1. Check if metrics are enabled: `grep "job_metrics" /opt/joblet/joblet-config.yml`
+1. Check the telemetry config: `grep -A5 "telemetry:" /opt/joblet/config/joblet-config.yml`
 2. Check if directory exists: `ls -la /opt/joblet/metrics`
 3. Check joblet logs: `journalctl -u joblet.service | grep metrics`
 

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -18,7 +18,7 @@ for future execution, architecture details, multi-node behavior, and persistence
 
 ## Overview
 
-Joblet supports scheduling jobs for future execution using RFC3339 timestamps. Scheduled jobs are:
+Joblet supports scheduling jobs for future execution using either relative durations (e.g. `30min`, `2h30m`) or absolute RFC3339 timestamps. Scheduled jobs are:
 
 - **Persisted** to DynamoDB for durability across restarts
 - **Node-specific** - each job runs only on the node that created it
@@ -29,7 +29,7 @@ Joblet supports scheduling jobs for future execution using RFC3339 timestamps. S
 
 | Feature | Behavior |
 |---------|----------|
-| Time Format | RFC3339 (e.g., `2025-01-15T10:30:00Z`) |
+| Time Format | Relative duration (e.g., `30min`, `2h30m`) or RFC3339 (e.g., `2025-01-15T10:30:00Z`) |
 | Timezone | UTC recommended, local time supported |
 | Persistence | DynamoDB (survives restarts) |
 | Node Affinity | Jobs execute on creating node only |
@@ -57,17 +57,36 @@ rnx job run --schedule="2025-01-15T14:00:00Z" \
 
 ### Schedule Format
 
-The schedule parameter must be in RFC3339 format:
+The schedule parameter accepts either a relative duration or an absolute timestamp.
+
+**Relative durations** (from now):
+
+```text
+45s        # 45 seconds from now
+30min      # 30 minutes from now
+1hour      # 1 hour from now
+2h30m      # 2 hours 30 minutes from now
+```
+
+Supported units are hours (`h`, `hour`, `hours`), minutes (`m`, `min`, `mins`,
+`minute`, `minutes`), and seconds (`s`, `sec`, `secs`, `second`, `seconds`).
+The minimum is 1 second and the maximum is 1 year.
+
+**Absolute timestamps** (RFC3339):
 
 ```text
 YYYY-MM-DDTHH:MM:SSZ          # UTC time
 YYYY-MM-DDTHH:MM:SS+HH:MM     # With positive offset
 YYYY-MM-DDTHH:MM:SS-HH:MM     # With negative offset
+YYYY-MM-DDTHH:MM:SS           # No timezone (assumed local time)
 ```
 
 **Examples:**
 
 ```bash
+# Relative duration
+--schedule="30min"
+
 # UTC time
 --schedule="2025-06-15T09:00:00Z"
 
@@ -83,16 +102,16 @@ YYYY-MM-DDTHH:MM:SS-HH:MM     # With negative offset
 Scheduled jobs support file uploads. Files are staged immediately and stored until execution:
 
 ```bash
-# Schedule job with file upload
+# Schedule job with file upload (files land under /work at their base name)
 rnx job run --schedule="2025-01-15T10:00:00Z" \
-    --upload=./data.csv:/workspace/data.csv \
-    python3 /workspace/process.py
+    --upload=./data.csv \
+    python3 process.py
 
 # Multiple files
 rnx job run --schedule="2025-01-15T10:00:00Z" \
-    --upload=./config.yaml:/app/config.yaml \
-    --upload=./script.py:/app/script.py \
-    python3 /app/script.py
+    --upload=./config.yaml \
+    --upload=./script.py \
+    python3 script.py
 ```
 
 ### Response
@@ -251,11 +270,11 @@ Jobs whose scheduled time passed during downtime execute immediately:
 # List all jobs (includes scheduled)
 rnx job list
 
-# Filter by status
-rnx job list --status=SCHEDULED
+# Filter by status client-side (job list has no server-side filter)
+rnx job list --json | jq '.[] | select(.status == "SCHEDULED")'
 
-# JSON output for scripting
-rnx job list --status=SCHEDULED --json
+# Just the UUIDs of scheduled jobs
+rnx job list --json | jq -r '.[] | select(.status == "SCHEDULED") | .id'
 ```
 
 ### View Scheduled Job Details
@@ -275,12 +294,8 @@ Node:       node-prod-1
 ### gRPC API
 
 ```protobuf
-// List scheduled jobs
-rpc ListJobs(ListJobsRequest) returns (ListJobsResponse);
-
-message ListJobsRequest {
-  string status_filter = 1;  // "SCHEDULED"
-}
+// List all jobs (no server-side filter; filter by status on the client)
+rpc ListJobs(EmptyRequest) returns (Jobs);
 ```
 
 ## Canceling Scheduled Jobs
@@ -288,12 +303,12 @@ message ListJobsRequest {
 ### Cancel Before Execution
 
 ```bash
-# Cancel a scheduled job
-rnx job stop <job-id>
-
-# Force cancel (if stuck)
-rnx job stop --force <job-id>
+# Cancel a scheduled job (before it starts)
+rnx job cancel <job-id>
 ```
+
+Use `rnx job cancel` for jobs still in `SCHEDULED` status. `rnx job stop` is for
+jobs that are already `RUNNING` (which transition to `STOPPED`, not `CANCELED`).
 
 **Result:**
 - Job removed from scheduler queue
@@ -321,7 +336,6 @@ rnx job delete <job-id>
 ### Not Supported
 
 - **Cron expressions** (e.g., `0 */2 * * *`)
-- **Relative scheduling** (e.g., "5 minutes from now")
 - **Job dependencies** (e.g., "run after job X completes")
 - **Cross-node execution** (jobs only run on creating node)
 
@@ -357,7 +371,7 @@ rnx job run --schedule="2025-01-15T10:00:00-05:00" ./script.sh
 rnx job run --schedule="2025-01-15T02:00:00Z" \
     --max-cpu=80 \
     --max-memory=2048 \
-    --max-io=50 \
+    --max-iobps=52428800 \
     ./nightly_backup.sh
 ```
 
@@ -422,7 +436,7 @@ rnx job run --schedule="2020-01-01T00:00:00Z" echo "runs now"
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| `invalid schedule format` | Non-RFC3339 timestamp | Use `YYYY-MM-DDTHH:MM:SSZ` format |
+| `invalid schedule` | Unrecognized schedule spec | Use a relative duration (e.g. `30min`) or RFC3339 timestamp |
 | `job not found` | Job deleted or wrong ID | Verify job ID with `rnx job list` |
 | `state client not available` | DynamoDB connection issue | Check state service logs |
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -327,9 +327,9 @@ rnx job run ls /opt/joblet         # No access to joblet internals
 
 ```bash
 # Controlled host OS access (ONLY during runtime building)
-# - Full host filesystem (read-only)
-# - Package managers available 
-# - /opt/joblet/runtimes writable
+# - Full host filesystem via OverlayFS (host root is a read-only lower layer)
+# - Writes are captured in an upper layer; the host filesystem is never modified
+# - Package managers available (runtime builds share host networking)
 # - Automatic cleanup creates isolated runtime structure
 ```
 
@@ -576,22 +576,19 @@ joblet:
 security:
   require_client_cert: true
   verify_client_cert: true
-  enable_rbac: true
-
-  # Comprehensive auditing
-  audit:
-    enabled: true
-    log_all_operations: true
-    log_failed_auth: true
-
-filesystem:
-  enable_chroot: true
-  readonly_rootfs: true
-
-process:
-  default_user: "nobody"
-  allow_setuid: false
 ```
+
+**Note on what is and isn't configurable:**
+
+- **RBAC is always on and has no toggle.** Authorization is enforced from the client certificate's OU field on every
+  request (see [Authorization and RBAC](#authorization-and-rbac)); there is no `security.enable_rbac` setting to turn
+  it off.
+- **setuid escalation is mitigated by the privilege drop, not by mount flags.** Standard jobs drop to uid/gid 65534
+  (`nobody`) before the command executes, so a setuid binary in the chroot cannot elevate them. Joblet does not
+  currently apply `nosuid`/`nodev`/`noexec` mount flags (the constants are defined in the codebase but not used in any
+  mount call), and there is no `process.allow_setuid`, `process.default_user`, or `filesystem.readonly_rootfs` setting.
+- **There is no built-in audit-log subsystem to configure.** The `security.audit.*` keys shown in earlier revisions of
+  this guide are not implemented. Use standard logging plus your host's audit tooling instead.
 
 ### File Permissions
 
@@ -613,6 +610,10 @@ sudo chown root:joblet /var/log/joblet/*.log
 
 ### Security Logging
 
+> **Illustrative.** The `security.audit.*` block below is **not** a supported configuration subsystem - Joblet does not
+> read these keys. Joblet writes operational logs (the daemon logs authorization decisions and job lifecycle events);
+> route those to a file or syslog with your host's logging stack rather than expecting a built-in audit config.
+
 ```yaml
 # Enable comprehensive logging
 logging:
@@ -627,6 +628,7 @@ logging:
     - type: "syslog"
       facility: "auth"
 
+# NOTE: the security.audit.* keys below are aspirational and NOT read by Joblet
 security:
   audit:
     enabled: true
@@ -688,8 +690,14 @@ echo "*/5 * * * * /opt/joblet/scripts/security_monitor.sh" | sudo crontab -
 
 ### SOC 2 Compliance
 
+> **Illustrative / aspirational - NOT currently supported.** The keys below (`security.audit.*`,
+> `access_control.require_mfa`, `session_timeout`, `logging.immutable_logs`, `log_integrity_check`) are **not**
+> implemented in Joblet and setting them has no effect. They are shown only to sketch the controls a SOC 2 program
+> typically expects; implement them at the host/platform layer (external audit log shipping, MFA on the operator's
+> access path, immutable log storage). RBAC and mTLS, which Joblet does enforce, are covered above.
+
 ```yaml
-# Configuration for SOC 2
+# Aspirational sketch - these keys are NOT read by Joblet
 security:
   audit:
     enabled: true

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -47,8 +47,8 @@ flowchart TD
 #### 1. Filesystem Volumes
 
 - **Purpose**: Persistent storage that survives job restarts and system reboots
-- **Implementation**: Directory-based storage on host filesystem
-- **Location**: `/var/lib/joblet/volumes/<volume-id>`
+- **Implementation**: Loop-mounted ext4 image (backing file) for size enforcement, with a plain-directory fallback if loop setup fails
+- **Location**: `/opt/joblet/volumes/<name>/data` (keyed by volume name)
 - **Features**:
     - Persistent across job executions
     - Survives daemon restarts
@@ -59,9 +59,9 @@ flowchart TD
 
 - **Purpose**: High-performance temporary storage
 - **Implementation**: tmpfs-based in-memory filesystem
-- **Location**: Mounted at `/var/lib/joblet/volumes/<volume-id>` (tmpfs)
+- **Location**: Mounted at `/opt/joblet/volumes/<name>/data` (tmpfs, keyed by volume name)
 - **Features**:
-    - Cleared after job completion
+    - Persists across jobs; cleared when the volume is removed (or on host reboot)
     - Ultra-fast I/O operations
     - No disk persistence
     - Ideal for temporary data and caches
@@ -86,7 +86,7 @@ flowchart TD
 // Volume cleanup flow
 1. Job completion triggers unmount
 2. VolumeManager: Unmounts volumes from job namespace
-3. Memory volumes: Data cleared automatically
+3. Memory volumes: tmpfs stays mounted; data persists across jobs and is cleared only when the volume is removed
 4. Filesystem volumes: Data persists for next use
 ```
 
@@ -118,7 +118,7 @@ sequenceDiagram
     Note over VM,VS: Cleanup
     J->>VM: job completion triggers unmount
     VM->>I: unmount volumes from job namespace
-    VM->>VS: memory → data cleared / filesystem → data persists
+    VM->>VS: both types persist across jobs; cleared only on volume removal
 ```
 
 ### Volume Store Implementation
@@ -130,17 +130,17 @@ volumes map[string]*domain.Volume
 }
 
 type Volume struct {
-ID          string
-Name        string
-Type        VolumeType // FILESYSTEM or MEMORY
-Size        int64  // Size in bytes
-Path        string // Host path
-MountPath   string // Path inside container
-CreatedAt   time.Time
-LastUsed    time.Time
-InUse       bool
-JobUUID     string // Current job using volume
+Name        string     // Unique volume identifier (also the store key)
+Type        VolumeType // filesystem or memory
+Size        string     // Size limit (e.g., "1GB", "500MB")
+SizeBytes   int64      // Parsed size in bytes
+Path        string     // Host filesystem path where volume is stored
+CreatedTime time.Time
+JobCount    int32      // Number of jobs currently using this volume
 }
+
+// MountPath is derived, not stored: "/volumes/<name>"
+// IsInUse() reports JobCount > 0
 ```
 
 ## Filesystem Isolation
@@ -246,8 +246,7 @@ service VolumeService {
   // Volume lifecycle operations
   rpc CreateVolume(CreateVolumeRequest) returns (CreateVolumeResponse);
   rpc ListVolumes(ListVolumesRequest) returns (ListVolumesResponse);
-  rpc GetVolume(GetVolumeRequest) returns (GetVolumeResponse);
-  rpc DeleteVolume(DeleteVolumeRequest) returns (DeleteVolumeResponse);
+  rpc RemoveVolume(RemoveVolumeRequest) returns (RemoveVolumeResponse);
 
   // Volume usage operations
   rpc AttachVolume(AttachVolumeRequest) returns (AttachVolumeResponse);
@@ -256,20 +255,17 @@ service VolumeService {
 
 message CreateVolumeRequest {
   string name = 1;
-  VolumeType type = 2;
-  int64 size_bytes = 3;
-  map<string, string> labels = 4;
+  string type = 2;   // "filesystem" or "memory"
+  string size = 3;   // e.g., "1GB", "500MB"
 }
 
 message Volume {
-  string id = 1;
-  string name = 2;
-  VolumeType type = 3;
+  string name = 1;
+  string type = 2;
+  string size = 3;
   int64 size_bytes = 4;
-  string status = 5;
-  google.protobuf.Timestamp created_at = 6;
-  google.protobuf.Timestamp last_used = 7;
-  string current_job_uuid = 8;
+  int32 job_count = 5;      // jobs currently using the volume
+  google.protobuf.Timestamp created_time = 6;
 }
 ```
 
@@ -278,22 +274,17 @@ message Volume {
 ```bash
 # Volume management commands
 rnx volume create <name> [options]
-  --size=SIZE       Volume size (e.g., 1GB, 512MB)
-  --type=TYPE       Volume type: filesystem|memory
-  --label=KEY=VAL   Metadata labels
+  --size=SIZE       Volume size (e.g., 1GB, 512MB) (required)
+  --type=TYPE       Volume type: filesystem|memory (default: filesystem)
 
-rnx volume list [options]
-  --filter=KEY=VAL  Filter by label
-  --format=FORMAT   Output format: table|json|yaml
+rnx volume list
+  # Table output by default; add the global --json flag for JSON
 
-rnx volume inspect <name>
-  Shows detailed volume information
+rnx volume remove <name>
+  # Volume must not be in use by any active jobs
 
-rnx volume remove <name> [options]
-  --force           Remove even if in use
-
-# Job execution with volumes
-rnx job run --volume=data:/data --volume=cache:/cache <command>
+# Job execution with volumes (bare volume name; mounted at /volumes/<name>)
+rnx job run --volume=data --volume=cache <command>
 ```
 
 ### Internal Interfaces
@@ -302,9 +293,9 @@ rnx job run --volume=data:/data --volume=cache:/cache <command>
 // VolumeManager interface
 type VolumeManager interface {
 CreateVolume(ctx context.Context, req *CreateVolumeRequest) (*Volume, error)
-GetVolume(ctx context.Context, id string) (*Volume, error)
+GetVolume(ctx context.Context, name string) (*Volume, error)
 ListVolumes(ctx context.Context, filter *VolumeFilter) ([]*Volume, error)
-DeleteVolume(ctx context.Context, id string) error
+RemoveVolume(ctx context.Context, name string) error
 
 // Job integration
 PrepareVolumes(ctx context.Context, jobID string, volumeIDs []string) error

--- a/docs/VOLUME_MANAGEMENT.md
+++ b/docs/VOLUME_MANAGEMENT.md
@@ -251,7 +251,7 @@ rnx volume create exact --size=1073741824  # Bytes (1GB)
 
 Volume names must:
 
-- Start with a letter
+- Start and end with an alphanumeric character (a leading digit is allowed)
 - Contain only letters, numbers, hyphens, underscores
 - Be unique within the Joblet instance
 - Be 1-63 characters long
@@ -261,9 +261,9 @@ Volume names must:
 rnx volume create user-data --size=1GB
 rnx volume create app_cache_v2 --size=500MB
 rnx volume create Dataset2024 --size=10GB
+rnx volume create 123data --size=1GB      # Leading digit is valid
 
 # Invalid names (will fail)
-rnx volume create 123data --size=1GB      # Starts with number
 rnx volume create my.data --size=1GB      # Contains period
 rnx volume create "my data" --size=1GB    # Contains space
 ```

--- a/docs/adr/003-namespace-isolation-strategy.md
+++ b/docs/adr/003-namespace-isolation-strategy.md
@@ -15,13 +15,17 @@ cgroup. Full isolation, like what Docker does. But we're not building another co
 execution system, and that changes the calculus significantly.
 
 The critical realization came when we looked at our users' actual needs. They weren't trying to run isolated
-microservices. They were running data processing jobs, build tasks, and system maintenance scripts. These jobs often
-needed to interact with local services, access specific ports, or communicate with other processes on the host.
+microservices. They were running data processing jobs, build tasks, and system maintenance scripts. Most of these jobs
+run untrusted code and should be kept off the host network stack, but one class - runtime builds - genuinely needs
+outbound internet access to download packages during the build. That tension is what drove a job-type-aware decision
+rather than a single blanket policy.
 
 ## Decision
 
-We chose a selective namespace isolation strategy. We isolate PID, mount, IPC, UTS, and cgroup namespaces, but
-deliberately share the network namespace with the host.
+We chose a selective, job-type-aware namespace isolation strategy. Production jobs (submitted through JobService via
+`rnx job run`) isolate PID, mount, IPC, UTS, cgroup, AND network namespaces. Runtime-build jobs (submitted through
+RuntimeService via `rnx runtime build`) isolate everything except the network namespace, which they deliberately share
+with the host so package managers can reach the internet during the build.
 
 Here's the reasoning for each choice:
 
@@ -31,59 +35,64 @@ Here's the reasoning for each choice:
 - **IPC namespace (isolated)**: Prevents jobs from accessing host IPC resources. Security win with minimal downside.
 - **UTS namespace (isolated)**: Jobs can have their own hostname. Nice for clarity, no compatibility impact.
 - **Cgroup namespace (isolated)**: Jobs can't see or modify host cgroup settings. Essential for resource isolation.
-- **Network namespace (shared)**: Jobs use the host network stack. This was the controversial one.
+- **Network namespace (isolated for production jobs, shared for runtime builds)**: Production jobs get their own
+  network namespace (`CLONE_NEWNET`) and reach the outside world through Joblet's bridge networking. Runtime-build jobs
+  share the host network stack so `apt`, `pip`, and `npm` can fetch dependencies during the build. This was the
+  controversial one.
 
-The network namespace decision was deliberate and carefully considered. Isolated networking means complexity - bridge
-networks, NAT, port mapping, DNS configuration. It means jobs can't easily talk to localhost services. It means
-debugging network issues becomes a nightmare.
+The network namespace decision was deliberate and carefully considered. Isolating production job networking means
+complexity - bridge networks, NAT, port mapping, DNS configuration - but Joblet manages that for you, and keeping
+untrusted job code off the host network stack is a real security boundary worth the cost. Runtime builds are a
+controlled, admin/maintainer-initiated exception where internet access during the build outweighs network isolation.
 
 ## Consequences
 
 ### The Good
 
-The shared network namespace has been a huge win for usability. Jobs can connect to databases running on localhost. They
-can bind to specific ports without port mapping configuration. They can use the host's DNS settings without any setup.
-It just works, which is what users expect from a job runner.
+Isolating production job networking keeps untrusted job code off the host network stack. A job can't sniff host
+traffic, can't bind to arbitrary host ports, and can't interfere with host network services. Outbound traffic is
+routed through Joblet's bridge networking, and named networks (`--network=...`) let operators segment workloads into
+separate security zones, while `--network=none` removes networking entirely for the most sensitive jobs.
 
-From an operational perspective, this choice eliminated an entire class of problems. No troubleshooting bridge networks.
-No NAT issues. No "why can't my job reach this service" tickets. Network traffic from jobs appears as regular host
-traffic, which means existing monitoring and security tools work without modification.
+From an operational perspective, Joblet manages the bridge, NAT, and DNS setup, so for most jobs the isolation is
+transparent - they get outbound access without any per-job configuration.
 
-Performance is better too. No virtual network interfaces, no packet routing between namespaces, no NAT overhead. For
-network-heavy jobs, this matters.
+Runtime builds keep the host network stack on purpose. Building a runtime means downloading packages, which needs
+working internet access with the host's DNS and routing. Because runtime builds are admin/maintainer-initiated and run
+in the builder environment, sharing the host network here is a controlled, deliberate exception rather than the default.
 
 ### The Trade-offs
 
-Obviously, sharing the network namespace means jobs aren't network-isolated. A job can see all network traffic on the
-host (though it still can't access processes or files without permission). A job can potentially interfere with network
-services.
+Isolated networking is more moving parts than sharing the host stack: bridges, NAT rules, and DNS all have to be set
+up and maintained. We accept that cost because network isolation is a real security boundary for the untrusted code
+production jobs run.
 
-We've accepted this trade-off because our threat model is different from a multi-tenant container platform. Joblet users
-are running their own code on their own infrastructure. The isolation is about preventing accidents and containing
-failures, not about protecting against malicious actors who already have code execution rights.
+The runtime-build exception means build jobs are NOT network-isolated - they can reach the host network stack. We
+accept this because builds are initiated by trusted roles and their explicit purpose is to pull in external
+dependencies.
 
 ### The Mitigations
 
-We didn't just accept the network sharing blindly. The other namespace isolations compensate significantly:
+Network isolation is reinforced by the other namespace isolations and the privilege model:
 
 - Jobs can't see host processes, so they can't attack services directly
 - Jobs can't access the host filesystem beyond their chroot, so they can't steal credentials
-- Jobs are resource-limited through cgroups, so they can't DoS the network
-- Jobs run with limited capabilities, reducing what they can do even with network access
+- Jobs are resource-limited through cgroups, so they can't DoS the host
+- Jobs run with limited capabilities, reducing what they can do
 - **Jobs run as unprivileged user (nobody/65534)** - Even if a job escapes the chroot, it cannot elevate privileges or
   damage the host system. This privilege dropping happens after isolation setup but before the job command executes.
+  Note that Joblet does not use a user namespace (`CLONE_NEWUSER`); the user context is isolated by this post-setup
+  privilege drop, not by UID remapping.
 
-We also made it clear in documentation that Joblet provides process and filesystem isolation, not full container-style
-network isolation. Users who need network isolation can run Joblet inside a container or VM.
+For the runtime-build exception, the same process, filesystem, and privilege isolations still apply - only the network
+namespace is shared.
 
 ### The Unexpected Benefits
 
-The simplified networking made some features trivial to implement. Service discovery just works because jobs can talk to
-localhost. Distributed tracing works because jobs share the host's network context. Integration with existing
-infrastructure required zero network configuration.
-
-It also made Joblet much easier to adopt. Teams could drop it into existing environments without redesigning their
-network architecture. No firewall rules to update, no service mesh to configure, no CNI plugins to debug.
+Driving network isolation off the job type kept the design simple: production jobs are secure by default, and the one
+place that genuinely needs host networking - runtime builds - opts out explicitly rather than every job having to opt
+in. Operators who need stricter segmentation compose named networks and `--network=none` on top of the default
+isolation without touching the daemon.
 
 ## Learn More
 

--- a/docs/adr/008-gpu-support-architecture.md
+++ b/docs/adr/008-gpu-support-architecture.md
@@ -4,14 +4,28 @@
 
 **Accepted** - September 2025
 
-**Implementation Status**: ✅ **Complete**
+**Implementation Status**: ⚠️ **Partial / Experimental**
 
-- GPU discovery and management: Implemented
-- Security isolation with cgroups device controller: Implemented
-- CUDA environment detection and mounting: Implemented
-- RNX CLI integration with `--gpu` and `--gpu-memory` flags: Implemented
+The user-facing allocation and validation path works, but the runtime isolation mechanisms
+described below are NOT yet wired into the execution path. Current state:
+
+- GPU discovery and management: Implemented (in-memory detection and allocation bookkeeping)
+- RNX CLI integration with `--gpu` and `--gpu-memory` flags: Implemented (flags parse and validate)
+- Compatibility validation (GPU count, runtime GPU/CUDA compatibility): Implemented
+- `CUDA_VISIBLE_DEVICES` / `NVIDIA_VISIBLE_DEVICES` env injection: Implemented
 - JSON API support: Implemented
-- Comprehensive testing framework: Implemented
+- Security isolation with cgroups v2 device controller: **NOT yet wired** — the cgroup device
+  code path logs and returns without writing device rules
+- Device-node creation (`mknod` for `/dev/nvidia*`) inside the job namespace: **NOT yet wired** —
+  the execution path only logs a placeholder; jobs do not receive `/dev/nvidia*` nodes
+- CUDA library bind-mounting into the job namespace: **NOT yet wired** — placeholder only
+- GPU memory enforcement and clearing between jobs: **NOT yet wired** — `--gpu-memory` only
+  filters candidate GPUs at selection time; it is not enforced at runtime
+
+> **Implementation note**: Working `mknod` device-node creation and CUDA bind-mount
+> implementations exist in the filesystem isolator (`internal/joblet/core/filesystem/isolator.go`,
+> `CreateGPUDeviceNodes` / `MountCUDALibraries`) but are currently dead code — they are not invoked
+> by the job execution path, which calls placeholder adapters that only log and return.
 
 > **Note**: GPU configuration in workflow definitions was removed when workflow orchestration was extracted to a
 > separate project (see [ADR-013](013-extract-workflow-to-separate-project.md)). Joblet exposes GPU allocation only
@@ -92,6 +106,13 @@ spreading (to minimize thermal contention).
 
 #### GPU Isolation Implementation
 
+> ⚠️ **Status: designed but NOT yet wired into the execution path.** The three mechanisms below
+> (cgroups v2 device control, `mknod` device-node creation, and CUDA bind-mounting) describe the
+> intended design. Today the execution path invokes placeholder adapters that log and return, so
+> jobs do not currently receive GPU device nodes, cgroup device rules, or bind-mounted CUDA
+> libraries. Only the `CUDA_VISIBLE_DEVICES` / `NVIDIA_VISIBLE_DEVICES` environment variables are
+> actually injected into GPU jobs.
+
 Extending Joblet's isolation system to support GPUs required careful integration with our existing namespace and cgroups
 architecture. GPUs were not originally designed for the fine-grained isolation that modern multi-tenant systems require,
 necessitating a sophisticated approach using native Linux kernel features.
@@ -144,10 +165,10 @@ This implementation delivers enterprise-grade GPU support that matches capabilit
 Slurm, while maintaining Joblet's core philosophy of using native Linux kernel features without containerization
 overhead. Users continue to benefit from Joblet's simplicity and directness, now extended to GPU workloads.
 
-**Robust Security Model**: Our GPU isolation maintains the same rigorous security standards as our existing CPU and
-memory isolation. GPU memory remains completely isolated between jobs using kernel-level features. The cgroups device
-controller ensures jobs cannot access unauthorized GPU resources, providing security equivalent to containerized
-solutions without the associated overhead.
+**Robust Security Model** (target state, not yet delivered): The GPU isolation design aims to match the same rigorous
+security standards as our existing CPU and memory isolation, using the cgroups v2 device controller to ensure jobs
+cannot access unauthorized GPU resources. ⚠️ This isolation is not yet enforced — the cgroup device rules and per-job
+device nodes are not currently written, so the memory- and device-isolation guarantees below are not in effect today.
 
 **User Experience Excellence**: The system eliminates the complexity traditionally associated with GPU computing. Users
 can request resources using simple, intuitive syntax ("2 GPUs with 16GB each") while the system automatically handles
@@ -214,8 +235,10 @@ can disable it again if issues arise. Non-GPU jobs continue to operate normally 
 GPU hardware was not originally designed with multi-tenancy security as a primary concern, requiring additional security
 measures to ensure safe operation in shared environments:
 
-**Memory Sanitization**: GPU memory is completely cleared between job allocations to prevent data leakage. While this
-process introduces latency, it is essential for maintaining security in multi-tenant environments.
+**Memory Sanitization** (planned, not yet reliable): GPU memory clearing between allocations is intended to prevent
+data leakage. ⚠️ The current implementation shells out to `nvidia-smi --gpu-reset` with a best-effort fallback that
+does not actually overwrite memory, so complete clearing is NOT guaranteed and should not be relied upon in
+multi-tenant environments today.
 
 **Execution Time Limits**: GPU kernel execution time limits prevent resource abuse, including unauthorized
 cryptocurrency mining or other malicious activities that could monopolize expensive GPU resources.

--- a/docs/adr/009-seccomp-syscall-filtering.md
+++ b/docs/adr/009-seccomp-syscall-filtering.md
@@ -73,8 +73,8 @@ networks.
 
 ### The Performance Story with BPF
 
-Let's talk about performance, because this is where the tradeoffs get real. Classic seccomp-BPF (what we use for Levels
-1-3) is fast because it's just a simple bytecode interpreter in the kernel. But it's limited - you can check syscall
+Let's talk about performance, because this is where the tradeoffs get real. Classic seccomp-BPF (what Levels 1-3 would
+use) is fast because it's just a simple bytecode interpreter in the kernel. But it's limited - you can check syscall
 numbers and basic arguments, but that's it.
 
 For Level 4, we're talking about eBPF (extended BPF). This is the new hotness in the Linux kernel. eBPF programs are
@@ -156,18 +156,18 @@ The key insight: CPU-bound workloads barely notice seccomp because they don't ma
 stuff (web servers, shell scripts) that sees the impact. But even then, we're talking single-digit percentage overhead
 for massive security gains.
 
-### How It Actually Works
+### How It Would Work
 
-When we spawn a job, right after we've set up the namespaces but before we exec the actual job command, we install the
-seccomp filter. We're using seccomp's BPF mode, which lets us write complex filters that can inspect syscall arguments,
-not just syscall numbers.
+When a job is spawned, right after the namespaces are set up but before the actual job command is exec'd, Joblet would
+install the seccomp filter. It would use seccomp's BPF mode, which lets you write complex filters that can inspect
+syscall arguments, not just syscall numbers.
 
 The beautiful thing about seccomp is that once you install a filter, you can't remove it. You can only make it more
-restrictive. So even if a job gets compromised, it can't disable its own syscall filtering.
+restrictive. So even if a job gets compromised, it couldn't disable its own syscall filtering.
 
-We're also using seccomp's SECCOMP_RET_ERRNO mode for blocked syscalls, which returns a clear error to the process
-instead of just killing it. This makes debugging much easier - you get "Operation not permitted" instead of mysterious
-crashes.
+We'd also use seccomp's SECCOMP_RET_ERRNO mode for blocked syscalls, which returns a clear error to the process
+instead of just killing it. This would make debugging much easier - you get "Operation not permitted" instead of
+mysterious crashes.
 
 ## Consequences
 


### PR DESCRIPTION
Corrects documentation drift found by auditing docs against the code. 
Highlights: GPU docs no longer claim end-to-end support that is currently a placeholder; 

`CONFIGURATION.md`/`METRICS_CONFIGURATION.md` no longer document config keys that don't exist (and were silently ignored); `scheduling`/`storage` docs no longer show commands and flags that error; `env-var` docs now document the reserved-variable hard-rejection; 