### PR TITLE
mark default node with isDefault instead of a duplicate "default" entry

### DIFF
--- a/docs/ADMIN_MIGRATION.md
+++ b/docs/ADMIN_MIGRATION.md
@@ -442,8 +442,9 @@ JOBLET_NODE=default
 ```yaml
 version: "3.0"
 nodes:
-  default:
+  admin:
     address: "localhost:50051"
+    isDefault: true
     cert: "..."
     key: "..."
     ca: "..."

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -589,13 +589,11 @@ The RNX client configuration file is typically located at `~/.rnx/rnx-config.yml
 ```yaml
 version: "3.0"
 
-# Default node configuration
-default_node: "default"
-
 nodes:
-  default:
+  admin:
     address: "joblet-server:50051"
     nodeId: "8f94c5b2-1234-5678-9abc-def012345678"  # Optional: Joblet node identifier
+    isDefault: true  # Used when --node is not specified; only one node may set this
 
     # Embedded certificates
     cert: |
@@ -761,9 +759,9 @@ Both certificate scripts (`scripts/certs_gen_embedded.sh` and the AWS variant
 `scripts/certs_gen_with_secretsmanager.sh`) generate one client certificate per role and write two kinds of client
 config:
 
-- `rnx-config.yml`: the operator's copy, with one node per role plus `default` (admin certificate). It contains the
-  admin key, so it stays on the server. On the server, select a role with `rnx --node <role> ...`.
-- `rnx-config-<role>.yml`: one self-contained file per role, with that role's node as `default`. Hand each party the
+- `rnx-config.yml`: the operator's copy, with one node per role; the `admin` node is marked `isDefault: true`. It
+  contains the admin key, so it stays on the server. On the server, select a role with `rnx --node <role> ...`.
+- `rnx-config-<role>.yml`: one self-contained file per role, with that role's node marked `isDefault: true`. Hand each party the
   file for its role and nothing else; a developer holding `rnx-config-developer.yml` never sees the admin key.
 
 The AWS variant additionally stores each role's certificate pair in Secrets Manager

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -459,8 +459,9 @@ security:
 # /opt/joblet/config/rnx-config.yml (Client)
 version: "3.0"
 nodes:
-  default:
+  admin:
     address: "192.168.1.100:50051"
+    isDefault: true
     cert: |
       -----BEGIN CERTIFICATE-----
       # Admin client certificate

--- a/docs/RNX_CLI_REFERENCE.md
+++ b/docs/RNX_CLI_REFERENCE.md
@@ -47,7 +47,7 @@ The following options are available across all RNX commands:
 
 ```bash
 --config <path>    # Path to configuration file (default: searches standard locations)
---node <name>      # Node name from configuration (default: "default")
+--node <name>      # Node name from configuration (default: the node marked isDefault: true)
 --json             # Output in JSON format
 --version, -v      # Show version information for both client and server
 --help, -h         # Show help for command
@@ -98,7 +98,7 @@ command.
 
 The certificate generation script (`certs_gen_embedded.sh`) creates one client certificate per role. As a client you
 normally receive a single `rnx-config-<role>.yml` from your operator; save it as `~/.rnx/rnx-config.yml` and run
-`rnx` with no extra flags, since your role is its `default` node. Operators working on the server itself have the
+`rnx` with no extra flags, since your role's node is marked `isDefault: true`. Operators working on the server itself have the
 combined `rnx-config.yml` with every role and pick one per invocation:
 
 ```bash
@@ -1465,8 +1465,9 @@ done
 ```yaml
 version: "3.0"
 nodes:
-  default:
+  production:
     address: "prod-server:50051"
+    isDefault: true  # used when --node is not specified; only one node may set this
     cert: |
       -----BEGIN CERTIFICATE-----
       ...
@@ -1496,8 +1497,8 @@ nodes:
 ### Usage with Different Nodes
 
 ```bash
-# Production jobs
-rnx --node=default run production-task.sh
+# Production jobs (marked isDefault: true, so --node is optional)
+rnx run production-task.sh
 
 # Staging tests
 rnx --node=staging run test-suite.sh

--- a/docs/SECRETS_MANAGER_INTEGRATION.md
+++ b/docs/SECRETS_MANAGER_INTEGRATION.md
@@ -223,7 +223,7 @@ Download the client config from **any** instance:
 scp ec2-user@instance1:/opt/joblet/config/rnx-config.yml ~/.rnx/
 
 # This config works with ALL instances!
-rnx --node=default job list
+rnx job list  # uses the node marked isDefault: true
 ```
 
 ## Certificate Lifecycle

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -539,7 +539,7 @@ Any other OU value fails every request.
 
 ```bash
 # 2. Use a node with a sufficient role
-# The generated rnx-config.yml contains one node per role plus "default" (admin certificate)
+# The generated rnx-config.yml contains one node per role; "admin" is marked isDefault: true
 rnx --node admin volume remove old-data
 
 # 3. Regenerate role certificates if needed

--- a/docs/adr/011-cqrs-architecture-with-joblet-persist.md
+++ b/docs/adr/011-cqrs-architecture-with-joblet-persist.md
@@ -129,7 +129,8 @@ persist:
 
 ```yaml
 nodes:
-  default:
+  admin:
+    isDefault: true  # used when no node name is specified
     address: "server:50051"        # joblet-core
     persistAddress: "server:50052"  # persist (optional)
 ```

--- a/docs/installation/PORT_CONFIGURATION.md
+++ b/docs/installation/PORT_CONFIGURATION.md
@@ -38,10 +38,12 @@ ssh -L 8443:localhost:443 ubuntu@ec2-host
 
 ```yaml
 # ~/.rnx/rnx-config.yml
-default:
-  server: "localhost:8443"  # Via SSH tunnel
-  # OR
-  # server: "ec2-host:443"  # Direct connection (if in same VPC)
+nodes:
+  admin:
+    isDefault: true  # used when no node name is specified
+    address: "localhost:8443"  # Via SSH tunnel
+    # OR
+    # address: "ec2-host:443"  # Direct connection (if in same VPC)
 ```
 
 ---

--- a/internal/rnx/cli/help.go
+++ b/internal/rnx/cli/help.go
@@ -29,8 +29,9 @@ func runConfigHelp(cmd *cobra.Command, args []string) error {
 	fmt.Println(`version: "3.0"
 
 nodes:
-  default:
+  admin:
     address: "192.168.1.100:50051"
+    isDefault: true
     cert: |
       -----BEGIN CERTIFICATE-----
       MIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
@@ -72,7 +73,7 @@ nodes:
 	fmt.Println("5. /opt/joblet/config/rnx-config.yml")
 	fmt.Println()
 	fmt.Println("Usage examples:")
-	fmt.Println("  rnx job list                    # uses 'default' node")
+	fmt.Println("  rnx job list                    # uses the node marked isDefault: true")
 	fmt.Println("  rnx --node=reader job list      # uses 'reader' node (read-only)")
 	fmt.Println("  rnx --node=production job list  # uses 'production' node")
 	fmt.Println("  rnx --config=my-rnx-config.yml job list  # uses custom config file")

--- a/internal/rnx/cli/nodes.go
+++ b/internal/rnx/cli/nodes.go
@@ -45,6 +45,8 @@ func runNodes(jsonOutput bool) error {
 	// Sort nodes for consistent output
 	sort.Strings(nodeNames)
 
+	defaultNode := common.NodeConfig.DefaultNodeName()
+
 	if jsonOutput {
 		var nodes []NodeInfo
 
@@ -60,7 +62,7 @@ func runNodes(jsonOutput bool) error {
 				Address: node.Address,
 				NodeId:  node.NodeId,
 				Status:  status,
-				Default: name == "default",
+				Default: name == defaultNode,
 			})
 		}
 
@@ -85,7 +87,7 @@ func runNodes(jsonOutput bool) error {
 
 		// Mark default node
 		marker := "  "
-		if name == "default" {
+		if name == defaultNode {
 			marker = "* "
 		}
 
@@ -121,9 +123,11 @@ func runNodes(jsonOutput bool) error {
 	}
 
 	fmt.Printf("Usage examples:\n")
-	fmt.Printf("  rnx job list                    # uses 'default' node\n")
+	if defaultNode != "" {
+		fmt.Printf("  rnx job list                    # uses '%s' node (default)\n", defaultNode)
+	}
 	for _, name := range nodeNames {
-		if name != "default" {
+		if name != defaultNode {
 			fmt.Printf("  rnx --node=%s job list         # uses '%s' node\n", name, name)
 			break
 		}

--- a/internal/rnx/cli/root.go
+++ b/internal/rnx/cli/root.go
@@ -79,8 +79,8 @@ func init() {
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&common.ConfigPath, "config", "",
 		"Path to client configuration file (searches common locations if not specified)")
-	rootCmd.PersistentFlags().StringVar(&common.NodeName, "node", "default",
-		"Node name from configuration file")
+	rootCmd.PersistentFlags().StringVar(&common.NodeName, "node", "",
+		"Node name from configuration file (defaults to the node marked isDefault: true)")
 	rootCmd.PersistentFlags().BoolVar(&common.JSONOutput, "json", false,
 		"Output in JSON format")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -123,11 +125,12 @@ type ClientConfig struct {
 
 // Node represents a single server configuration with embedded certificates
 type Node struct {
-	Address string `yaml:"address"`
-	NodeId  string `yaml:"nodeId,omitempty"` // Unique identifier of the Joblet node (optional, for display purposes)
-	Cert    string `yaml:"cert"`             // Embedded PEM certificate
-	Key     string `yaml:"key"`              // Embedded PEM private key
-	CA      string `yaml:"ca"`               // Embedded PEM CA certificate
+	Address   string `yaml:"address"`
+	NodeId    string `yaml:"nodeId,omitempty"`    // Unique identifier of the Joblet node (optional, for display purposes)
+	IsDefault *bool  `yaml:"isDefault,omitempty"` // Marks this node as the one used when --node is not specified
+	Cert      string `yaml:"cert"`                // Embedded PEM certificate
+	Key       string `yaml:"key"`                 // Embedded PEM private key
+	CA        string `yaml:"ca"`                  // Embedded PEM CA certificate
 }
 
 // BuffersConfig holds buffer and pub-sub configuration
@@ -782,17 +785,55 @@ func LoadClientConfig(configPath string) (*ClientConfig, error) {
 		return nil, fmt.Errorf("no nodes configured in %s", configPath)
 	}
 
+	// Validate that at most one node is marked as default
+	var defaults []string
+	for name, node := range config.Nodes {
+		if node.IsDefault != nil && *node.IsDefault {
+			defaults = append(defaults, name)
+		}
+	}
+	if len(defaults) > 1 {
+		sort.Strings(defaults)
+		return nil, fmt.Errorf("multiple nodes marked with isDefault: true in %s: %s (only one node can be the default)",
+			configPath, strings.Join(defaults, ", "))
+	}
+
 	return &config, nil
 }
 
+// DefaultNodeName returns the name of the node used when no --node is specified.
+// Resolution order: the node marked isDefault: true, then a node literally named
+// "default" (legacy configs), then the only node if exactly one is configured.
+// Returns empty string if no default can be determined.
+func (c *ClientConfig) DefaultNodeName() string {
+	for name, node := range c.Nodes {
+		if node.IsDefault != nil && *node.IsDefault {
+			return name
+		}
+	}
+	if _, exists := c.Nodes["default"]; exists {
+		return "default"
+	}
+	if len(c.Nodes) == 1 {
+		for name := range c.Nodes {
+			return name
+		}
+	}
+	return ""
+}
+
 // GetNode retrieves the configuration for a named Joblet server node.
-// If nodeName is empty, defaults to "default" node.
+// If nodeName is empty, resolves the default node via DefaultNodeName.
 // Returns the Node configuration containing server address and certificates,
 // or error if the specified node name is not found in the configuration.
 // Used by RNX client to select which Joblet server to connect to.
 func (c *ClientConfig) GetNode(nodeName string) (*Node, error) {
 	if nodeName == "" {
-		nodeName = "default"
+		nodeName = c.DefaultNodeName()
+		if nodeName == "" {
+			return nil, fmt.Errorf("no default node configured: mark one node with isDefault: true or use --node to select one of: %s",
+				strings.Join(c.ListNodes(), ", "))
+		}
 	}
 
 	node, exists := c.Nodes[nodeName]

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -497,6 +497,175 @@ func TestClientConfigMethods(t *testing.T) {
 	})
 }
 
+func TestDefaultNodeResolution(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	t.Run("isDefault marks the default node", func(t *testing.T) {
+		config := &ClientConfig{
+			Version: "3.0",
+			Nodes: map[string]*Node{
+				"admin":  {Address: "admin.example.com:50051", IsDefault: boolPtr(true)},
+				"reader": {Address: "reader.example.com:50051"},
+			},
+		}
+
+		if name := config.DefaultNodeName(); name != "admin" {
+			t.Errorf("DefaultNodeName() = %q, want 'admin'", name)
+		}
+
+		node, err := config.GetNode("")
+		if err != nil {
+			t.Fatalf("GetNode(\"\") unexpected error: %v", err)
+		}
+		if node.Address != "admin.example.com:50051" {
+			t.Errorf("Expected default address 'admin.example.com:50051', got '%s'", node.Address)
+		}
+	})
+
+	t.Run("isDefault wins over node named default", func(t *testing.T) {
+		config := &ClientConfig{
+			Version: "3.0",
+			Nodes: map[string]*Node{
+				"default": {Address: "legacy.example.com:50051"},
+				"admin":   {Address: "admin.example.com:50051", IsDefault: boolPtr(true)},
+			},
+		}
+
+		if name := config.DefaultNodeName(); name != "admin" {
+			t.Errorf("DefaultNodeName() = %q, want 'admin'", name)
+		}
+	})
+
+	t.Run("legacy node named default still works", func(t *testing.T) {
+		config := &ClientConfig{
+			Version: "3.0",
+			Nodes: map[string]*Node{
+				"default": {Address: "legacy.example.com:50051"},
+				"reader":  {Address: "reader.example.com:50051"},
+			},
+		}
+
+		if name := config.DefaultNodeName(); name != "default" {
+			t.Errorf("DefaultNodeName() = %q, want 'default'", name)
+		}
+	})
+
+	t.Run("single node is the implicit default", func(t *testing.T) {
+		config := &ClientConfig{
+			Version: "3.0",
+			Nodes: map[string]*Node{
+				"prod": {Address: "prod.example.com:50051"},
+			},
+		}
+
+		if name := config.DefaultNodeName(); name != "prod" {
+			t.Errorf("DefaultNodeName() = %q, want 'prod'", name)
+		}
+	})
+
+	t.Run("no resolvable default returns error", func(t *testing.T) {
+		config := &ClientConfig{
+			Version: "3.0",
+			Nodes: map[string]*Node{
+				"prod":    {Address: "prod.example.com:50051"},
+				"staging": {Address: "staging.example.com:50051"},
+			},
+		}
+
+		if name := config.DefaultNodeName(); name != "" {
+			t.Errorf("DefaultNodeName() = %q, want empty", name)
+		}
+		if _, err := config.GetNode(""); err == nil {
+			t.Errorf("GetNode(\"\") expected error when no default is resolvable")
+		}
+	})
+}
+
+func TestLoadClientConfigDefaultValidation(t *testing.T) {
+	writeConfig := func(t *testing.T, content string) string {
+		t.Helper()
+		configPath := filepath.Join(t.TempDir(), "rnx-config.yml")
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+		return configPath
+	}
+
+	t.Run("single isDefault loads", func(t *testing.T) {
+		configPath := writeConfig(t, `version: "3.0"
+nodes:
+  admin:
+    address: "localhost:50051"
+    isDefault: true
+    cert: "c"
+    key: "k"
+    ca: "ca"
+  reader:
+    address: "localhost:50051"
+    cert: "c"
+    key: "k"
+    ca: "ca"`)
+
+		config, err := LoadClientConfig(configPath)
+		if err != nil {
+			t.Fatalf("LoadClientConfig() error = %v", err)
+		}
+		if name := config.DefaultNodeName(); name != "admin" {
+			t.Errorf("DefaultNodeName() = %q, want 'admin'", name)
+		}
+	})
+
+	t.Run("multiple isDefault rejected", func(t *testing.T) {
+		configPath := writeConfig(t, `version: "3.0"
+nodes:
+  admin:
+    address: "localhost:50051"
+    isDefault: true
+    cert: "c"
+    key: "k"
+    ca: "ca"
+  reader:
+    address: "localhost:50051"
+    isDefault: true
+    cert: "c"
+    key: "k"
+    ca: "ca"`)
+
+		_, err := LoadClientConfig(configPath)
+		if err == nil {
+			t.Fatalf("LoadClientConfig() expected error for multiple isDefault nodes")
+		}
+		if !strings.Contains(err.Error(), "isDefault") {
+			t.Errorf("Expected error to mention isDefault, got: %v", err)
+		}
+	})
+
+	t.Run("isDefault false does not count", func(t *testing.T) {
+		configPath := writeConfig(t, `version: "3.0"
+nodes:
+  admin:
+    address: "localhost:50051"
+    isDefault: true
+    cert: "c"
+    key: "k"
+    ca: "ca"
+  reader:
+    address: "localhost:50051"
+    isDefault: false
+    cert: "c"
+    key: "k"
+    ca: "ca"`)
+
+		config, err := LoadClientConfig(configPath)
+		if err != nil {
+			t.Fatalf("LoadClientConfig() error = %v", err)
+		}
+		if name := config.DefaultNodeName(); name != "admin" {
+			t.Errorf("DefaultNodeName() = %q, want 'admin'", name)
+		}
+	})
+}
+
 // Helper function
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||

--- a/scripts/certs_gen_embedded.sh
+++ b/scripts/certs_gen_embedded.sh
@@ -319,15 +319,16 @@ print_info "Updating client configuration with embedded certificates..."
 CLIENT_CONFIG="$CONFIG_DIR/rnx-config.yml"
 
 # Create client configuration with embedded certificates.
-# "default" uses the admin certificate; one node per role is added so
+# "admin" is marked isDefault: true; one node per role is added so
 # clients can select a role with: rnx --node <role> ...
 cat > "$CLIENT_CONFIG" << EOF
 version: "3.0"
 
 nodes:
-  default:
+  admin:
     address: "$SERVER_ADDRESS:50051"
     nodeId: "$NODE_ID"
+    isDefault: true
     cert: |
 $(read_cert_for_yaml admin-client-cert.pem "      ")
     key: |
@@ -337,6 +338,8 @@ $(read_cert_for_yaml ca-cert.pem "      ")
 EOF
 
 for ROLE in $CLIENT_ROLES; do
+    # admin is already present above as the default node
+    [ "$ROLE" = "admin" ] && continue
     cat >> "$CLIENT_CONFIG" << EOF
   $ROLE:
     address: "$SERVER_ADDRESS:50051"
@@ -359,9 +362,10 @@ for ROLE in $CLIENT_ROLES; do
 version: "3.0"
 
 nodes:
-  default:
+  $ROLE:
     address: "$SERVER_ADDRESS:50051"
     nodeId: "$NODE_ID"
+    isDefault: true
     cert: |
 $(read_cert_for_yaml "$ROLE-client-cert.pem" "      ")
     key: |

--- a/scripts/certs_gen_with_secretsmanager.sh
+++ b/scripts/certs_gen_with_secretsmanager.sh
@@ -721,9 +721,10 @@ cat > "$CLIENT_CONFIG" << EOF
 version: "3.0"
 
 nodes:
-  default:
+  admin:
     address: "$SERVER_ADDRESS:50051"
     nodeId: "$NODE_ID"
+    isDefault: true
     cert: |
 $(read_cert_for_yaml admin-client-cert.pem "      ")
     key: |
@@ -733,6 +734,8 @@ $(read_cert_for_yaml ca-cert.pem "      ")
 EOF
 
 for ROLE in $CLIENT_ROLES; do
+    # admin is already present above as the default node
+    [ "$ROLE" = "admin" ] && continue
     cat >> "$CLIENT_CONFIG" << EOF
   $ROLE:
     address: "$SERVER_ADDRESS:50051"
@@ -755,9 +758,10 @@ for ROLE in $CLIENT_ROLES; do
 version: "3.0"
 
 nodes:
-  default:
+  $ROLE:
     address: "$SERVER_ADDRESS:50051"
     nodeId: "$NODE_ID"
+    isDefault: true
     cert: |
 $(read_cert_for_yaml "$ROLE-client-cert.pem" "      ")
     key: |

--- a/scripts/rnx-config-template.yml
+++ b/scripts/rnx-config-template.yml
@@ -8,9 +8,10 @@ version: "3.0"
 # with the following structure:
 #
 # nodes:
-#   default:
+#   admin:
 #     address: "SERVER_ADDRESS:50051"               # joblet gRPC service (job execution, logs, metrics)
 #     nodeId: "8f94c5b2-1234-5678-9abc-def012345678"  # Optional: Joblet node identifier for display
+#     isDefault: true                               # Optional: used when --node is not specified (only one node may set this)
 #     cert: |
 #       -----BEGIN CERTIFICATE-----
 #       [admin certificate content]


### PR DESCRIPTION
The generated `rnx-config.yml` duplicated the admin credentials under a second node named `default` so that `rnx` commands could omit `--node`. That meant two copies of the same cert/key in every config, and the default was tied to a magic node name.